### PR TITLE
Add pandoc as alternative to roaster

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,120 @@
+$x$ math at the start of the document
+
+This document is to test $\LaTeX$ rendering with [markdown-preview-plus](https://atom.io/packages/markdown-preview-plus).
+
+$x_1, x_2, \dots, x_N$ conflict with _italics_ syntax?
+
+$(f*g*h)(x)$ conflict with `*` syntax?
+
+$[a+b](c+d)$ conflict with link syntax?
+
+Use `\[` on separate lines:
+
+\[
+\int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+\]
+
+
+Use `\[` on the same line:
+
+\[ \frac{-b \pm \sqrt{b^2-4ac}}{2a} \]
+
+Use `$$` on separate lines:
+
+$$
+a+b
+$$
+
+_italics_ and **bold** and [links](http://atom.io)
+
+----
+
+$k \times k$, $n \times 2$, $2 \times n$, $\times$
+
+$x \cdot y$, $\cdot$
+
+$\sqrt{x^2+y^2+z^2}$
+
+$\alpha \beta \gamma$
+
+----
+
+a \$5 bill
+
+```
+$x
+```
+
+```
+\$
+```
+
+`\$`, `\[ \]`, `$x$`, $x$
+
+----
+
+For all $x$ and $y$ in $\mathbb{R}^k$ it is true that
+$$
+\newcommand{sca}[1]{\langle #1 \rangle}
+|\sca{x,y}|^2 \le \sca{x,x} \cdot \sca{y,y},
+$$
+where $\sca{\cdot,\cdot}$ denotes the inner product $\sca{(x_1,\dots,x_k), (y_1,\dots,y_k)} = \sum_{i=1}^k x_i y_i$.
+
+----
+
+\[
+p(\mathbf{m}) \sim \mathcal{N}(\mathbf{m}) e^{-\sum_{i} \beta_i m_i}
+\]
+
+\[
+\langle \vec{m} \rangle =
+\frac{1}{Z(\vec{\beta})}\vec{m}(\mu)
+\sum_{\mu\in\mathcal{G}}
+e^{-\vec{\beta}\cdot\vec{m}(\mu)}
+\]
+
+----
+
+Notice below that the `\[`-separated display math doesn't have a blank line before and after (i.e. in an actual $\LaTeX$ document it woulnd't be placed in a separate paragraph):
+
+The _characteristic polynomial_ $\chi(\lambda)$ of the
+$3 \times 3$ matrix
+\[ \left( \begin{array}{ccc}
+a & b & c \\
+d & e & f \\
+g & h & i \end{array} \right)\]
+is given by the formula
+\[ \chi(\lambda) = \left| \begin{array}{ccc}
+\lambda - a & -b & -c \\
+-d & \lambda - e & -f \\
+-g & -h & \lambda - i \end{array} \right|.\]
+
+This is a long line: $\chi(\lambda) = a e i-a e \lambda -a f h-a i \lambda +a \lambda ^2-b d i+b d \lambda +b f g+c d h-c e g+c g \lambda -e i \lambda +e \lambda ^2+f h \lambda +i \lambda ^2-\lambda ^3 $
+
+----
+
+#Math $x^2$ in heading 1
+
+##Math $x^2$ in heading 2
+
+###Math $x^2$ in heading 3
+
+####Math $x^2$ in heading 4
+
+_math $x^2$ in emphasis_
+
+**math $x^2$ in bold**
+
+[math $x^2$ in link](http://www.mathjax.org/)
+
+`math $x^2$ in code`
+
+This is broken `$$`
+
+$$
+a+b
+$$
+
+\[ \frac{-b \pm \sqrt{b^2-4ac}}{2a} \]
+
+An $N\times N$ grid.

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -2,11 +2,10 @@ $x$ math at the start of the document
 
 This document is to test $\LaTeX$ rendering with [markdown-preview-plus](https://atom.io/packages/markdown-preview-plus).
 
-$x_1, x_2, \dots, x_N$ conflict with _italics_ syntax?
+**Math environment Syntax testing**
 
-$(f*g*h)(x)$ conflict with `*` syntax?
-
-$[a+b](c+d)$ conflict with link syntax?
+Inline Math should work with `$`  $\frac{x+y}{y}$
+and `\(` \(\frac{x+y}{y}\)
 
 Use `\[` on separate lines:
 
@@ -25,9 +24,13 @@ $$
 a+b
 $$
 
-_italics_ and **bold** and [links](http://atom.io)
+Use `$$` on the same line:
+
+$$E=mc^2$$
 
 ----
+
+**Some Tex Functions**
 
 $k \times k$, $n \times 2$, $2 \times n$, $\times$
 
@@ -37,9 +40,31 @@ $\sqrt{x^2+y^2+z^2}$
 
 $\alpha \beta \gamma$
 
+$$
+\begin{aligned}
+x\ &= y\\
+mc^2\ &= E
+\end{aligned}
+$$
+
 ----
 
-a \$5 bill
+**Escaped Math environments**
+
+In the following examples no math environments should render:
+
+a $5, a $10 and a \$100 Bill.
+
+All McScrooge sees
+
+$$
+
+and even more:
+
+$$
+
+\\[x+y\]
+\\(x+y\)
 
 ```
 $x
@@ -49,19 +74,26 @@ $x
 \$
 ```
 
-`\$`, `\[ \]`, `$x$`, $x$
+`\$`, `\[ \]`, `$x$`
 
 ----
+
+**Testing \newcommand**
 
 For all $x$ and $y$ in $\mathbb{R}^k$ it is true that
 $$
 \newcommand{sca}[1]{\langle #1 \rangle}
 |\sca{x,y}|^2 \le \sca{x,x} \cdot \sca{y,y},
 $$
-where $\sca{\cdot,\cdot}$ denotes the inner product $\sca{(x_1,\dots,x_k), (y_1,\dots,y_k)} = \sum_{i=1}^k x_i y_i$.
+
+<!-- newcommand not in environment-->
+\newcommand{\scalong}[1]{(#1_1,\dots,#1_k)}
+
+where $\sca{\cdot,\cdot}$ denotes the inner product $\sca{\scalong{x}, \scalong{x}} = \sum_{i=1}^k x_i y_i$.
 
 ----
 
+**Testing several math fonts**
 \[
 p(\mathbf{m}) \sim \mathcal{N}(\mathbf{m}) e^{-\sum_{i} \beta_i m_i}
 \]
@@ -89,9 +121,11 @@ is given by the formula
 -d & \lambda - e & -f \\
 -g & -h & \lambda - i \end{array} \right|.\]
 
-This is a long line: $\chi(\lambda) = a e i-a e \lambda -a f h-a i \lambda +a \lambda ^2-b d i+b d \lambda +b f g+c d h-c e g+c g \lambda -e i \lambda +e \lambda ^2+f h \lambda +i \lambda ^2-\lambda ^3 $
+This is a long line: $\chi(\lambda) = a e i-a e \lambda -a f h-a i \lambda +a \lambda ^2-b d i+b d \lambda +b f g+c d h-c e g+c g \lambda -e i \lambda +e \lambda ^2+f h \lambda +i \lambda ^2-\lambda ^3$
 
 ----
+
+**Does it work in different MD elements?**
 
 #Math $x^2$ in heading 1
 
@@ -101,6 +135,12 @@ This is a long line: $\chi(\lambda) = a e i-a e \lambda -a f h-a i \lambda +a \l
 
 ####Math $x^2$ in heading 4
 
+$x_1, x_2, \dots, x_N$ should not conflict with `_` _italics_?
+
+$(f*g*h)(x)$ should not conflict with `*` *syn***tax**?
+
+$[a+b](c+d)$ should not conflict link [syntax](#)?
+
 _math $x^2$ in emphasis_
 
 **math $x^2$ in bold**
@@ -109,12 +149,23 @@ _math $x^2$ in emphasis_
 
 `math $x^2$ in code`
 
-This is broken `$$`
+~~math $x^2$ in strikethrough~~
 
-$$
-a+b
-$$
+**In Tables**
 
-\[ \frac{-b \pm \sqrt{b^2-4ac}}{2a} \]
+| Left-Aligned  | Center Aligned  | Right Aligned |
+| :------------ |:---------------:| -----:|
+| $a+b$         | some wordy text | $1600 |
+|               | $$
+A=\mathbf{A}=\underline{A}=\begin{pmatrix}
+a_{11} & a_{12} & \cdots & a_{1n}\\
+a_{21} & a_{22} & \cdots & a_{2n}\\
+\vdots & \vdots &        & \vdots\\
+a_{m1} & a_{m2} & \cdots & a_{mn}\\
+\end{pmatrix} = (a_{ij})
+$$                                |   $12 |
+|               |                 |    $1 |
 
-An $N\times N$ grid.
+**In Image Captions**
+
+![$$a^2+b^2=c^2$$](https://raw.githubusercontent.com/Galadirith/markdown-preview-plus/master/imgs/mpp-full-res-invert.png)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ current editor using the keymap `ctrl-shift-m`.
     ````bash
     $ apm install mathjax-wrapper
     ````
+  4. Optionally you may use pandoc to render the Markdown preview. Please have a look at the pandoc section below troubleshooting.
 
 ## Troubleshooting
 
@@ -84,6 +85,40 @@ you have experienced a problem not listed here please open up an
   3.  You should see a progress message `Installing Modules`, and will be
       complete when it displays `Installing Modules done` which may take
       1-5mins.
+
+- **I want to use pandoc but it doesn't work**  
+  For instructions have a look at the pandoc section below.
+
+## Pandoc
+
+Below you will find an installation guide for pandoc and an explanation of all settings
+
+1. [Install pandoc](http://pandoc.org/installing.html)
+2. Run `which pandoc` and note the full path to the pandoc executable
+3. On the Markdown-Preview-Plus Settings Page
+    - enable **Enable Pandoc Parser**
+    - paste the result of 2. into **Pandoc Options: Path**
+4. voilà - pandoc should work
+
+The Pandoc options give you furthermore the possibility to
+
+* define custom [pandoc arguments](http://pandoc.org/README.html#options)
+* adjust the [markdown flavor](http://pandoc.org/README.html#pandocs-markdown)
+* enable [citation replacement](http://pandoc.org/README.html#citations) for references like &#x5B;&#x40;smith04&#x5D;
+    - Therefore enable **Pandoc Options: Citations**
+    - MPP will now search for any file named *bibliography.bib* and *custom.csl* from the markdown's directory up. The first files that are matching will be used for pandocs citations. You can change the filenames it is searching for with the option **Bibliography (bibfile)** and **Bibliography Style (cslfile)**. Here is a small example how it works:
+    ````
+    /
+    |-- bibliography.bib     <-- will be used by README.md
+    |-- custom.csl           <-- will be used by README.md & RANDOM.md
+    |-- src
+    |   |-- bibliography.bib <-- will be used by RANDOM.md
+    |   |-- otherbib.bib     <-- will not be used as filename does not match
+    |   `-- md
+    |       `-- RANDOM.md
+    `-- README.md
+    ````
+    Effictively the arguments `--csl=/custom.csl --bibliography=/bibliography.bib` are used for `/README.md` and `--csl=/custom.csl --bibliography=/src/bibliography.bib` for `/src/md/RANDOM.md` 
 
 ## License
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -41,10 +41,10 @@ module.exports =
       default: false
     enableRenderingWithPandoc:
       type: 'boolean'
-      default: true
+      default: false
     pandocPath:
       type: 'string'
-      default: '/usr/local/bin/pandoc'
+      default: 'pandoc'
 
   activate: ->
     atom.commands.add 'atom-workspace',

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -39,6 +39,12 @@ module.exports =
     enableLatexRenderingByDefault:
       type: 'boolean'
       default: false
+    enableRenderingWithPandoc:
+      type: 'boolean'
+      default: true
+    pandocPath:
+      type: 'string'
+      default: '/usr/local/bin/pandoc'
 
   activate: ->
     atom.commands.add 'atom-workspace',

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -39,12 +39,18 @@ module.exports =
     enableLatexRenderingByDefault:
       type: 'boolean'
       default: false
-    enableRenderingWithPandoc:
+    pandocEnablePandoc:
       type: 'boolean'
       default: false
-    pandocPath:
+    pandocOptsPath:
       type: 'string'
       default: 'pandoc'
+    pandocOptsMarkdownFlavor:
+      type: 'string'
+      default: 'markdown-raw_tex+tex_math_single_backslash'
+    pandocOptsArguments:
+      type: 'array'
+      default: []
 
   activate: ->
     atom.commands.add 'atom-workspace',

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,12 +21,15 @@ module.exports =
     breakOnSingleNewline:
       type: 'boolean'
       default: false
+      order: 0
     liveUpdate:
       type: 'boolean'
       default: true
+      order: 10
     openPreviewInSplitPane:
       type: 'boolean'
       default: true
+      order: 20
     grammars:
       type: 'array'
       default: [
@@ -36,21 +39,66 @@ module.exports =
         'text.plain'
         'text.plain.null-grammar'
       ]
+      order: 30
     enableLatexRenderingByDefault:
       type: 'boolean'
       default: false
-    pandocEnablePandoc:
+      order: 40
+    enablePandoc:
       type: 'boolean'
       default: false
-    pandocOptsPath:
+      title: 'Enable Pandoc Parser'
+      order: 100
+    pandocPath:
       type: 'string'
       default: 'pandoc'
-    pandocOptsMarkdownFlavor:
-      type: 'string'
-      default: 'markdown-raw_tex+tex_math_single_backslash'
-    pandocOptsArguments:
+      title: 'Pandoc Options: Path'
+      description: 'Please specify the correct path to your pandoc executable'
+      dependencies: ['enablePandoc']
+      order: 110
+    pandocArguments:
       type: 'array'
       default: []
+      title: 'Pandoc Options: Commandline Arguments'
+      description: 'Enter comma seperated pandoc commandline options e.g. `--smart, --normalize` '
+      dependencies: ['enablePandoc']
+      order: 120
+    pandocMarkdownFlavor:
+      type: 'string'
+      default: 'markdown-raw_tex+tex_math_single_backslash'
+      title: 'Pandoc Options: Markdown Flavor'
+      description: 'Enter the pandoc markdown flavor you want'
+      dependencies: ['enablePandoc']
+      order: 130
+    pandocBibliography:
+      type: 'boolean'
+      default: false
+      title: 'Pandoc Options: Citations'
+      description: 'Enable this for bibliography parsing'
+      dependencies: ['enablePandoc']
+      order: 140
+    pandocRemoveReferences:
+      type: 'boolean'
+      default: true
+      title: 'Pandoc Options: Remove References'
+      description: 'Removes references at the end of the HTML preview'
+      dependencies: ['pandocBibliography']
+      order: 150
+    pandocBIBFile:
+      type: 'string'
+      default: 'bibliography.bib'
+      title: 'Pandoc Options: Bibliography (bibfile)'
+      description: 'Name of bibfile to search for recursivly'
+      dependencies: ['pandocBibliography']
+      order: 160
+    pandocCSLFile:
+      type: 'string'
+      default: 'custom.csl'
+      title: 'Pandoc Options: Bibliography Style (cslfile)'
+      description: 'Name of cslfile to search for recursivly'
+      dependencies: ['pandocBibliography']
+      order: 170
+
 
   activate: ->
     atom.commands.add 'atom-workspace',

--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -1,0 +1,129 @@
+cheerio = require 'cheerio'
+pdc = require 'pdc'
+_ = require 'underscore-plus'
+
+# Arguments for pandoc
+args = null
+
+# Pandocs markdown flavor
+flavor = null
+
+# Callback function for result
+callback = null
+
+# Whether to render the math
+renderMath = null
+
+# Current markdown text
+currentText = null
+
+# Local Mathjax Path
+mathjaxPath = null
+
+###*
+ * Sets local mathjaxPath if available
+ ###
+getMathJaxPath = () ->
+  try
+    path = require 'path'
+    mathjaxPath = atom.packages.getLoadedPackage('mathjax-wrapper')
+    mathjaxPath = path.join mathjaxPath.path, 'node_modules/MathJax/MathJax.js'
+    mathjaxPath = "=#{mathjaxPath}"
+  catch e
+    mathjaxPath = ''
+
+###*
+ * Sets local variables needed for everything
+ * @param {string} document in markdown
+ * @param {boolean} whether to render the math with mathjax
+ * @param {function} callbackFunction
+ ###
+setSettings = (text, math, cb) ->
+  currentText = text
+  renderMath = math
+  callback = cb
+  pdc.path = atom.config.get('markdown-preview-plus.pandocOptsPath')
+  flavor = atom.config.get('markdown-preview-plus.pandocOptsMarkdownFlavor')
+  args = atom.config.get('markdown-preview-plus.pandocOptsArguments')
+  getMathJaxPath() unless mathjaxPath?
+  args.push "--mathjax#{mathjaxPath}" if renderMath
+  args.push '--bibliography=/Users/leipert/testbib.bib'
+
+###*
+ * Handle error response from pdc
+ * @param {error} Returned error
+ * @param {string} Returned HTML
+ * @return {array} with Arguments for callbackFunction (error set to null)
+ ###
+handleError = (error, html) ->
+  search = /pandoc-citeproc: reference ([\S]+) not found\n?/ig
+  matches = error.message.match search
+  message = error.message.replace search, ''
+  if message.length > 0
+    error = null
+    matches = _.uniq matches
+    html = "<b>#{ matches.join('<br>') }</b>"
+    matches = matches.forEach (match) ->
+      match = match.replace search, '$1'
+      r = new RegExp "@#{match}", 'gi'
+      currentText = currentText.replace(r, "&#64;#{match}")
+    currentText = html + '<br>' + currentText
+    pdc currentText, flavor, 'html', args, handleHTML
+  else
+    message = error.message.replace /\n/g, '<br>'
+    html = "<h1>Pandoc Error</h1><p><b>#{message}</b></p>"
+  [null, html]
+
+###*
+ * Adjusts all math environments in HTML
+ * @param {string} HTML to be adjusted
+ * @return {string} HTML with adjusted math environments
+ ###
+handleMath = (html) ->
+  o = cheerio.load("<div>#{html}</div>")
+  o('.math').each (i, elem) ->
+    math = cheerio(this).text()
+    # Set mode if it is block math
+    mode = if math.indexOf('\\[') > -1  then '; mode=display' else ''
+
+    # Remove sourrounding \[ \] and \( \)
+    math = math.replace(/\\[[()\]]/g, '')
+    newContent =
+      '<span class="math">' +
+      "<script type='math/tex#{mode}'>#{math}</script>" +
+      '</span>'
+
+    cheerio(this).replaceWith newContent
+
+  o('div').html()
+
+###*
+ * Handle successful response from pdc
+ * @param {string} Returned HTML
+ * @return {array} with Arguments for callbackFunction (error set to null)
+ ###
+handleSuccess = (html) ->
+  html = handleMath html if renderMath
+  [null, html]
+
+###*
+ * Handle response from pdc
+ * @param {Object} error if thrown
+ * @param {string} Returned HTML
+ ###
+handleResponse = (error, html) ->
+  array = if error? then handleError error, html else handleSuccess html
+  callback.apply callback, array
+
+###*
+ * Renders markdown with pandoc
+ * @param {string} document in markdown
+ * @param {boolean} whether to render the math with mathjax
+ * @param {function} callbackFunction
+ ###
+renderPandoc = (text, renderMath, cb) ->
+  setSettings text, renderMath, cb
+  pdc text, flavor, 'html', args, handleResponse
+
+module.exports =
+  renderPandoc: renderPandoc

--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -68,7 +68,7 @@ handleError = (error, html) ->
       r = new RegExp "@#{match}", 'gi'
       currentText = currentText.replace(r, "&#64;#{match}")
     currentText = html + '<br>' + currentText
-    pdc currentText, flavor, 'html', args, handleHTML
+    pdc currentText, flavor, 'html', args, handleResponse
   else
     message = error.message.replace /\n/g, '<br>'
     html = "<h1>Pandoc Error</h1><p><b>#{message}</b></p>"

--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -59,7 +59,7 @@ handleError = (error, html) ->
   search = /pandoc-citeproc: reference ([\S]+) not found\n?/ig
   matches = error.message.match search
   message = error.message.replace search, ''
-  if message.length > 0
+  if message.length is 0
     error = null
     matches = _.uniq matches
     html = "<b>#{ matches.join('<br>') }</b>"

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -45,9 +45,9 @@ render = (text, filePath, renderLaTeX, callback) ->
     html = resolveImagePaths(html, filePath)
     callback(null, html.trim())
 
-  if atom.config.get('markdown-preview-plus.pandocEnablePandoc')
+  if atom.config.get('markdown-preview-plus.enablePandoc')
     pandocHelper ?= require './pandoc-helper'
-    pandocHelper.renderPandoc text, renderLaTeX, callbackFunction
+    pandocHelper.renderPandoc text, filePath, renderLaTeX, callbackFunction
   else
     roaster ?= require path.join(packagePath, 'node_modules/roaster/lib/roaster')
     options =

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -5,6 +5,7 @@ fs = require 'fs-plus'
 Highlights = require 'highlights'
 {$} = require 'atom-space-pen-views'
 roaster = null # Defer until used
+pandoc = null # Defer until used
 {scopeForFenceName} = require './extension-helper'
 mathjaxHelper = require './mathjax-helper'
 
@@ -34,22 +35,27 @@ exports.toHTML = (text='', filePath, grammar, renderLaTeX, callback) ->
     callback(null, html)
 
 render = (text, filePath, renderLaTeX, callback) ->
-  roaster ?= require path.join(packagePath, 'node_modules/roaster/lib/roaster')
-  options =
-    mathjax: renderLaTeX
-    sanitize: false
-    breaks: atom.config.get('markdown-preview-plus.breakOnSingleNewline')
-
   # Remove the <!doctype> since otherwise marked will escape it
   # https://github.com/chjj/marked/issues/354
   text = text.replace(/^\s*<!doctype(\s+.*)?>\s*/i, '')
 
-  roaster text, options, (error, html) =>
+  callbackFunction = (error, html) ->
     return callback(error) if error?
-
     html = sanitize(html)
     html = resolveImagePaths(html, filePath)
     callback(null, html.trim())
+
+  if atom.config.get('markdown-preview-plus.enableRenderingWithPandoc')
+    pandoc ?= require path.join(packagePath, 'node_modules/pdc/pdc')
+    pandoc.path = atom.config.get('markdown-preview-plus.pandocPath')
+    pandoc text, 'markdown-raw_tex', 'html', ['--mathjax'], callbackFunction
+  else
+    roaster ?= require path.join(packagePath, 'node_modules/roaster/lib/roaster')
+    options =
+      mathjax: renderLaTeX
+      sanitize: false
+      breaks: atom.config.get('markdown-preview-plus.breakOnSingleNewline')
+    roaster text, options, callbackFunction
 
 sanitize = (html) ->
   o = cheerio.load("<div>#{html}</div>")

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grim": "^1.0.0",
     "highlights": "^1.0.0",
     "pathwatcher": "^3.0",
+    "pdc": "~0.2.2",
     "roaster": "https://github.com/Galadirith/roaster/tarball/marked-mathjax",
     "temp": "^0.8.1",
     "underscore-plus": "^1.0.0",


### PR DESCRIPTION
TODO-LIST:
   - [x] Implement pandoc functionality
      - [x] Make pandoc path configurable
      - [x] Make pandoc markdown flavour configurable
      - [x] Toggle pandoc functionality
      - [x] Give possibility to add own command line arguments
   - [x] Check if all current functionality works
   - [x] Add stress document
   - [x] Cleanup & comment code
   - [x] Add Documentation for Pandoc

Fixes #2, #11, #24, #17, #18 and #20

**Original Message:**

Hey @Galadirith. I know, this may come surprising and I also know there is [lierdakil/markdown-preview-pandoc](https://github.com/lierdakil/markdown-preview-pandoc).
But as far as I am concerned the math there with `--webtex` looks meh.

Is there any way to establish pandoc as an optional renderer?
I added basic pandoc rendering, but it is impossible for me to get the math rendered in the preview pane.
Could you give me any hints?
