### PR TITLE
Fixed strikethrough layout 

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -448,4 +448,19 @@
     height: 20px;
     width: 20px;
   }
+
+  del {
+    text-decoration: none;
+    position: relative;
+  }
+
+  del::after {
+    border-bottom: 1px solid black;
+    content: "";
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 50%;
+  }
+
 }


### PR DESCRIPTION
`~~Math in strikethrough $E=mc^2$ fixed~~` now does not look like this anymore

![screen shot 2015-03-09 at 03 11 38](https://cloud.githubusercontent.com/assets/2906107/6548979/5d8ad982-c60a-11e4-903f-3e18e3440025.png)

But like this:

![screen shot 2015-03-09 at 03 11 07](https://cloud.githubusercontent.com/assets/2906107/6548980/5d8eae9a-c60a-11e4-814b-daec1d43229a.png)
