### PR TITLE
Make image version query a timestamp fixes #60

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Edward Fauchon-Jones
+Copyright (c) 2014-2015 Edward Fauchon-Jones
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -70,3 +70,32 @@ This repository incorporates code from
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
+
+------------------------------------------------------------------------
+
+This repository incorporates code from
+[Jasmine-Matchers](https://github.com/JamieMason/Jasmine-Matchers) covered by
+the following terms:
+
+> Copyright © Jamie Mason, @fold_left,
+> https://github.com/JamieMason
+>
+> Permission is hereby granted, free of charge, to any person
+> obtaining a copy of this software and associated documentation files
+> (the "Software"), to deal in the Software without restriction,
+> including without limitation the rights to use, copy, modify, merge,
+> publish, distribute, sublicense, and/or sell copies of the Software,
+> and to permit persons to whom the Software is furnished to do so,
+> subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+> BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+> ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+> CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -8,7 +8,7 @@ roaster = null # Defer until used
 pandocHelper = null # Defer until used
 {scopeForFenceName} = require './extension-helper'
 mathjaxHelper = require './mathjax-helper'
-watchr = require 'watchr'
+pathWatcher = require 'pathwatcher'
 
 MarkdownPreviewView = null # Defer until used
 isMarkdownPreviewView = (object) ->
@@ -25,7 +25,6 @@ highlighter = null
 {resourcePath} = atom.getLoadSettings()
 packagePath = path.dirname(__dirname)
 imgVersion = []
-watchers = []
 
 exports.toDOMFragment = (text='', filePath, grammar, renderLaTeX, callback) ->
   render text, filePath, renderLaTeX, (error, html) ->
@@ -98,14 +97,14 @@ sanitize = (html) ->
   o('*').removeAttr(attribute) for attribute in attributesToRemove
   o.html()
 
-imgListener = (event, src) ->
-  if imgVersion[src]?
-    if fs.isFileSync(src)
+srcClosure = (src) ->
+  return (event, path) ->
+    if event is 'change' and fs.isFileSync(src)
       imgVersion[src] = Date.now()
     else
       imgVersion[src] = 'deleted'
     renderPreviews()
-  return
+    return
 
 resolveImagePaths = (html, filePath) ->
   [rootDirectory] = atom.project.relativizePath(filePath)
@@ -131,12 +130,7 @@ resolveImagePaths = (html, filePath) ->
 
       if not imgVersion[src] > 0 and fs.isFileSync(src)
         imgVersion[src] = Date.now()
-        dir = path.join(src, '..')
-        if not watchers[dir]
-          watchers[dir] = watchr.watch
-            path: dir
-            listener: imgListener
-
+        pathWatcher.watch src, srcClosure(src)
 
       src = "#{src}?v=#{imgVersion[src]}" if imgVersion[src]
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -102,7 +102,7 @@ srcClosure = (src) ->
     if event is 'change' and fs.isFileSync(src)
       imgVersion[src] = Date.now()
     else
-      imgVersion[src] = 'deleted'
+      imgVersion[src] = null
     renderPreviews()
     return
 
@@ -128,7 +128,7 @@ resolveImagePaths = (html, filePath) ->
 
       # Use most recent version of image
 
-      if not imgVersion[src] > 0 and fs.isFileSync(src)
+      if not imgVersion[src] and fs.isFileSync(src)
         imgVersion[src] = Date.now()
         pathWatcher.watch src, srcClosure(src)
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "roaster": "https://github.com/Galadirith/roaster/tarball/marked-mathjax",
     "temp": "^0.8.1",
     "underscore-plus": "^1.0.0",
+    "watchr": "^2.4.13",
     "wrench": "^1.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "roaster": "https://github.com/Galadirith/roaster/tarball/marked-mathjax",
     "temp": "^0.8.1",
     "underscore-plus": "^1.0.0",
-    "watchr": "^2.4.13",
     "wrench": "^1.5.0"
   },
   "devDependencies": {

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -320,8 +320,8 @@ describe "MarkdownPreviewView", ->
           expect(newImg3Ver).not.toEqual('deleted')
           expect(parseInt(newImg3Ver)).toBeGreaterThan(parseInt(img3Ver))
 
-    describe "when an image is previewed, deleted then restored", ->
-      it "sets the query value to a timestamp, deleted and finally a more recent timestamp", ->
+    describe "when a previewed image is deleted then restored", ->
+      it "removes the query timestamp and restores the timestamp after a rerender", ->
         [imageURL, imageVer] = []
 
         waitsForPromise -> atom.workspace.open(filePath)
@@ -340,20 +340,20 @@ describe "MarkdownPreviewView", ->
           not imageURL.endsWith imageVer
 
         runs ->
-          expect(getImageVersion(img1Path, imageURL)).toBe 'deleted'
-
+          expect(imageURL).toBe img1Path
           fs.writeFileSync img1Path, "clearly not a png but good enough for tests"
+          preview.renderMarkdown()
 
         waitsFor "image src attribute to update", ->
           imageURL = preview.find("img[alt=img1]").attr('src')
-          not imageURL.endsWith 'deleted'
+          imageURL isnt img1Path
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)
           expect(parseInt(newImageVer)).toBeGreaterThan(parseInt(imageVer))
 
-    describe "when an image is previewed, renamed and then restored with original name", ->
-      it "sets the query value to a timestamp, deleted and finally a more recent timestamp", ->
+    describe "when a previewed image is renamed and then restored with its original name", ->
+      it "removes the query timestamp and restores the timestamp after a rerender", ->
         [imageURL, imageVer] = []
 
         waitsForPromise -> atom.workspace.open(filePath)
@@ -372,13 +372,13 @@ describe "MarkdownPreviewView", ->
           not imageURL.endsWith imageVer
 
         runs ->
-          expect(getImageVersion(img1Path, imageURL)).toBe 'deleted'
-
+          expect(imageURL).toBe img1Path
           fs.renameSync img1Path + "trol", img1Path
+          preview.renderMarkdown()
 
         waitsFor "image src attribute to update", ->
           imageURL = preview.find("img[alt=img1]").attr('src')
-          not imageURL.endsWith 'deleted'
+          imageURL isnt img1Path
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -2,7 +2,6 @@ path = require 'path'
 fs = require 'fs-plus'
 temp = require 'temp'
 MarkdownPreviewView = require '../lib/markdown-preview-view'
-pathWatcher = require 'pathwatcher'
 url = require 'url'
 queryString = require 'querystring'
 
@@ -211,12 +210,13 @@ describe "MarkdownPreviewView", ->
           imageURL = preview.find("img[alt=img1]").attr('src')
           imageVer = getImageVersion(img1Path, imageURL)
           expect(imageVer).not.toEqual('deleted')
-
           fs.writeFileSync img1Path, "still clearly not a png ;D"
 
-        waitsFor "image src attribute to update", ->
-          imageURL = preview.find("img[alt=img1]").attr('src')
-          not imageURL.endsWith imageVer
+        waitsFor "image src attribute to update",
+          ->
+            imageURL = preview.find("img[alt=img1]").attr('src')
+            not imageURL.endsWith imageVer
+          , 10000
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)
@@ -275,9 +275,11 @@ describe "MarkdownPreviewView", ->
 
           fs.writeFileSync img1Path, "still clearly not a png ;D"
 
-        waitsFor "img1 src attribute to update", ->
-          img1URL = preview.find("img[alt=img1]").attr('src')
-          not img1URL.endsWith img1Ver
+        waitsFor "img1 src attribute to update",
+          ->
+            img1URL = preview.find("img[alt=img1]").attr('src')
+            not img1URL.endsWith img1Ver
+          , 10000
 
         runs ->
           expectQueryValues
@@ -288,12 +290,13 @@ describe "MarkdownPreviewView", ->
           expect(newImg1Ver).not.toEqual('deleted')
           expect(parseInt(newImg1Ver)).toBeGreaterThan(parseInt(img1Ver))
           img1Ver = newImg1Ver
-
           fs.writeFileSync img2Path, "still clearly not a png either ;D"
 
-        waitsFor "img2 src attribute to update", ->
-          img2URL = preview.find("img[alt=img2]").attr('src')
-          not img2URL.endsWith img2Ver
+        waitsFor "img2 src attribute to update",
+          ->
+            img2URL = preview.find("img[alt=img2]").attr('src')
+            not img2URL.endsWith img2Ver
+          , 10000
 
         runs ->
           expectQueryValues
@@ -307,9 +310,11 @@ describe "MarkdownPreviewView", ->
 
           fs.writeFileSync img3Path, "you better believe i'm not a png ;D"
 
-        waitsFor "img3 src attribute to update", ->
-          img3URL = preview.find("img[alt=img3]").attr('src')
-          not img3URL.endsWith img3Ver
+        waitsFor "img3 src attribute to update",
+          ->
+            img3URL = preview.find("img[alt=img3]").attr('src')
+            not img3URL.endsWith img3Ver
+          , 10000
 
         runs ->
           expectQueryValues
@@ -335,18 +340,21 @@ describe "MarkdownPreviewView", ->
 
           fs.unlinkSync img1Path
 
-        waitsFor "image src attribute to update", ->
-          imageURL = preview.find("img[alt=img1]").attr('src')
-          not imageURL.endsWith imageVer
+        waitsFor "image src attribute to update after deletion",
+          ->
+            imageURL = preview.find("img[alt=img1]").attr('src')
+            not imageURL.endsWith imageVer
+          , 10000
 
         runs ->
           expect(getImageVersion(img1Path, imageURL)).toBe 'deleted'
-
           fs.writeFileSync img1Path, "clearly not a png but good enough for tests"
 
-        waitsFor "image src attribute to update", ->
-          imageURL = preview.find("img[alt=img1]").attr('src')
-          not imageURL.endsWith 'deleted'
+        waitsFor "image src attribute to update after creation",
+          ->
+            imageURL = preview.find("img[alt=img1]").attr('src')
+            not imageURL.endsWith 'deleted'
+          , 10000
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)
@@ -367,18 +375,22 @@ describe "MarkdownPreviewView", ->
 
           fs.renameSync img1Path, img1Path + "trol"
 
-        waitsFor "image src attribute to update", ->
-          imageURL = preview.find("img[alt=img1]").attr('src')
-          not imageURL.endsWith imageVer
+        waitsFor "image src attribute to update",
+          ->
+            imageURL = preview.find("img[alt=img1]").attr('src')
+            not imageURL.endsWith imageVer
+          , 10000
 
         runs ->
           expect(getImageVersion(img1Path, imageURL)).toBe 'deleted'
 
           fs.renameSync img1Path + "trol", img1Path
 
-        waitsFor "image src attribute to update", ->
-          imageURL = preview.find("img[alt=img1]").attr('src')
-          not imageURL.endsWith 'deleted'
+        waitsFor "image src attribute to update",
+          ->
+            imageURL = preview.find("img[alt=img1]").attr('src')
+            not imageURL.endsWith 'deleted'
+          , 10000
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 fs = require 'fs-plus'
 temp = require 'temp'
 MarkdownPreviewView = require '../lib/markdown-preview-view'
+pathWatcher = require 'pathwatcher'
 url = require 'url'
 queryString = require 'querystring'
 
@@ -210,13 +211,12 @@ describe "MarkdownPreviewView", ->
           imageURL = preview.find("img[alt=img1]").attr('src')
           imageVer = getImageVersion(img1Path, imageURL)
           expect(imageVer).not.toEqual('deleted')
+
           fs.writeFileSync img1Path, "still clearly not a png ;D"
 
-        waitsFor "image src attribute to update",
-          ->
-            imageURL = preview.find("img[alt=img1]").attr('src')
-            not imageURL.endsWith imageVer
-          , 10000
+        waitsFor "image src attribute to update", ->
+          imageURL = preview.find("img[alt=img1]").attr('src')
+          not imageURL.endsWith imageVer
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)
@@ -275,11 +275,9 @@ describe "MarkdownPreviewView", ->
 
           fs.writeFileSync img1Path, "still clearly not a png ;D"
 
-        waitsFor "img1 src attribute to update",
-          ->
-            img1URL = preview.find("img[alt=img1]").attr('src')
-            not img1URL.endsWith img1Ver
-          , 10000
+        waitsFor "img1 src attribute to update", ->
+          img1URL = preview.find("img[alt=img1]").attr('src')
+          not img1URL.endsWith img1Ver
 
         runs ->
           expectQueryValues
@@ -290,13 +288,12 @@ describe "MarkdownPreviewView", ->
           expect(newImg1Ver).not.toEqual('deleted')
           expect(parseInt(newImg1Ver)).toBeGreaterThan(parseInt(img1Ver))
           img1Ver = newImg1Ver
+
           fs.writeFileSync img2Path, "still clearly not a png either ;D"
 
-        waitsFor "img2 src attribute to update",
-          ->
-            img2URL = preview.find("img[alt=img2]").attr('src')
-            not img2URL.endsWith img2Ver
-          , 10000
+        waitsFor "img2 src attribute to update", ->
+          img2URL = preview.find("img[alt=img2]").attr('src')
+          not img2URL.endsWith img2Ver
 
         runs ->
           expectQueryValues
@@ -310,11 +307,9 @@ describe "MarkdownPreviewView", ->
 
           fs.writeFileSync img3Path, "you better believe i'm not a png ;D"
 
-        waitsFor "img3 src attribute to update",
-          ->
-            img3URL = preview.find("img[alt=img3]").attr('src')
-            not img3URL.endsWith img3Ver
-          , 10000
+        waitsFor "img3 src attribute to update", ->
+          img3URL = preview.find("img[alt=img3]").attr('src')
+          not img3URL.endsWith img3Ver
 
         runs ->
           expectQueryValues
@@ -340,21 +335,18 @@ describe "MarkdownPreviewView", ->
 
           fs.unlinkSync img1Path
 
-        waitsFor "image src attribute to update after deletion",
-          ->
-            imageURL = preview.find("img[alt=img1]").attr('src')
-            not imageURL.endsWith imageVer
-          , 10000
+        waitsFor "image src attribute to update", ->
+          imageURL = preview.find("img[alt=img1]").attr('src')
+          not imageURL.endsWith imageVer
 
         runs ->
           expect(getImageVersion(img1Path, imageURL)).toBe 'deleted'
+
           fs.writeFileSync img1Path, "clearly not a png but good enough for tests"
 
-        waitsFor "image src attribute to update after creation",
-          ->
-            imageURL = preview.find("img[alt=img1]").attr('src')
-            not imageURL.endsWith 'deleted'
-          , 10000
+        waitsFor "image src attribute to update", ->
+          imageURL = preview.find("img[alt=img1]").attr('src')
+          not imageURL.endsWith 'deleted'
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)
@@ -375,22 +367,18 @@ describe "MarkdownPreviewView", ->
 
           fs.renameSync img1Path, img1Path + "trol"
 
-        waitsFor "image src attribute to update",
-          ->
-            imageURL = preview.find("img[alt=img1]").attr('src')
-            not imageURL.endsWith imageVer
-          , 10000
+        waitsFor "image src attribute to update", ->
+          imageURL = preview.find("img[alt=img1]").attr('src')
+          not imageURL.endsWith imageVer
 
         runs ->
           expect(getImageVersion(img1Path, imageURL)).toBe 'deleted'
 
           fs.renameSync img1Path + "trol", img1Path
 
-        waitsFor "image src attribute to update",
-          ->
-            imageURL = preview.find("img[alt=img1]").attr('src')
-            not imageURL.endsWith 'deleted'
-          , 10000
+        waitsFor "image src attribute to update", ->
+          imageURL = preview.find("img[alt=img1]").attr('src')
+          not imageURL.endsWith 'deleted'
 
         runs ->
           newImageVer = getImageVersion(img1Path, imageURL)


### PR DESCRIPTION
The rerendering of the preview was also decoupled from the pathwatcher
listener. Now all pathwatcher events are captured and processed
including all those triggered by the same file modification as described
in atom/node-pathwatcher#50.