### PR TITLE
Fix bib support.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -41,6 +41,9 @@ used for Pandocs citations. You can change the filenames it is searching for
 by changing the options **Bibliography (bibfile)** and **Bibliography Style
 (cslfile)** on the settings page.
 
+You can set a fallback bibfile and cslfile if the current repository
+has none of it's own.
+
 Here is a small example how it works:
 
 ```` text
@@ -55,9 +58,9 @@ Here is a small example how it works:
 └── README.md
 ````
 
-Effectively the arguments `--csl=/custom.csl --bibliography=/bibliography.bib`
-are used for `/README.md` and `--csl=/custom.csl
---bibliography=/src/bibliography.bib` for `/src/md/RANDOM.md`
+Effectively the arguments `--csl=./custom.csl --bibliography=./bibliography.bib`
+are used for `./README.md` and `--csl=./custom.csl
+--bibliography=./src/bibliography.bib` for `./src/md/RANDOM.md`
 
 [issue-46]: https://github.com/Galadirith/markdown-preview-plus/issues/46#issuecomment-124324926
 [pandoc-cit]: http://pandoc.org/README.html#citations

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -97,6 +97,13 @@ module.exports =
       description: 'Name of bibfile to search for recursivly'
       dependencies: ['pandocBibliography']
       order: 160
+    pandocBIBFileFallback:
+      type: 'string'
+      default: ''
+      title: 'Pandoc Options: Fallback Bibliography (bibfile)'
+      description: 'Full path to fallback bibfile'
+      dependencies: ['pandocBibliography']
+      order: 165
     pandocCSLFile:
       type: 'string'
       default: 'custom.csl'
@@ -104,6 +111,13 @@ module.exports =
       description: 'Name of cslfile to search for recursivly'
       dependencies: ['pandocBibliography']
       order: 170
+    pandocCSLFileFallback:
+      type: 'string'
+      default: ''
+      title: 'Pandoc Options: Fallback Bibliography Style (cslfile)'
+      description: 'Full path to fallback cslfile'
+      dependencies: ['pandocBibliography']
+      order: 175
 
 
   activate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -66,7 +66,7 @@ module.exports =
       type: 'array'
       default: []
       title: 'Pandoc Options: Commandline Arguments'
-      description: 'Enter comma separated pandoc commandline options e.g. `--smart, --normalize`'
+      description: 'Comma separated pandoc arguments e.g. `--smart, --filter=/bin/exe`. Please use long argument names.'
       dependencies: ['enablePandoc']
       order: 120
     pandocMarkdownFlavor:

--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -31,7 +31,7 @@ findFileRecursive = (filePath, fileName) ->
     bibFile
   else
     newPath = path.join bibFile, '..'
-    if newPath isnt filePath
+    if newPath isnt filePath and not _.contains(atom.project.getPaths(), newPath)
       findFileRecursive newPath, fileName
     else
       false
@@ -46,14 +46,16 @@ setPandocOptions = (filePath) ->
   atomConfig = atom.config.get('markdown-preview-plus')
   pdc.path = atomConfig.pandocPath
   config.flavor = atomConfig.pandocMarkdownFlavor
-  config.args = atom.config.get('markdown-preview-plus.pandocArguments')
+  config.args = atomConfig.pandocArguments
   getMathJaxPath() unless config.mathjax?
   config.args.push "--mathjax#{config.mathjax}" if config.renderMath
   if atomConfig.pandocBibliography
     bibFile = findFileRecursive filePath, atomConfig.pandocBIBFile
+    bibFile = atomConfig.pandocBIBFileFallback unless bibFile
     config.args.push "--bibliography=#{bibFile}" if bibFile
     cslFile = findFileRecursive filePath, atomConfig.pandocCSLFile
-    config.args.push "--csl=#{cslFile}" if bibFile and cslFile
+    cslFile = atomConfig.pandocCSLFileFallback unless cslFile
+    config.args.push "--csl=#{cslFile}" if cslFile
 
 ###*
  * Handle error response from pdc

--- a/spec/markdown-preview-pandoc-helper-spec.coffee
+++ b/spec/markdown-preview-pandoc-helper-spec.coffee
@@ -1,0 +1,161 @@
+path = require 'path'
+fs = require 'fs-plus'
+temp = require 'temp'
+wrench = require 'wrench'
+{$} = require 'atom-space-pen-views'
+pandocHelper = require '../lib/pandoc-helper.coffee'
+
+bibFile = 'test.bib'
+cslFile = 'foo.csl'
+
+tempPath = null
+file = null
+
+describe "Markdown preview plus pandoc helper", ->
+  [workspaceElement, preview] = []
+
+  beforeEach ->
+    fixturesPath = path.join(__dirname, 'fixtures')
+    tempPath = temp.mkdirSync('atom')
+    wrench.copyDirSyncRecursive(fixturesPath, tempPath, forceDelete: true)
+    atom.project.setPaths([tempPath])
+
+    jasmine.useRealClock()
+
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
+
+    waitsForPromise ->
+      atom.packages.activatePackage("markdown-preview-plus")
+
+  describe "PandocHelper::findFileRecursive", ->
+
+    fR = pandocHelper.__testing__.findFileRecursive
+
+    it "should return bibFile in the same directory", ->
+      runs ->
+        bibPath = path.join(tempPath, 'subdir', bibFile)
+        fs.writeFileSync bibPath, ''
+        found = fR path.join(tempPath, 'subdir', 'simple.md'), bibFile
+        expect(found).toEqual(bibPath)
+
+    it "should return bibFile in a parent directory", ->
+      runs ->
+        bibPath = path.join(tempPath, bibFile)
+        fs.writeFileSync bibPath, ''
+        found = fR path.join(tempPath, 'subdir', 'simple.md'), bibFile
+        expect(found).toEqual(bibPath)
+
+    it "shouldn't return bibFile in a out of scope directory", ->
+      runs ->
+        fs.writeFileSync path.join(tempPath, '..', bibFile), ''
+        found = fR path.join(tempPath, 'subdir', 'simple.md'), bibFile
+        expect(found).toEqual(false)
+
+  describe "PandocHelper::getArguments", ->
+    getArguments = pandocHelper.__testing__.getArguments
+
+    it 'should work with empty arguments', ->
+      atom.config.set 'markdown-preview-plus.pandocArguments', []
+      result = getArguments(null)
+      expect(result.length).toEqual(0)
+
+    it 'should filter empty arguments', ->
+      args =
+        foo: 'bar'
+        empty: null
+        none: 'lala'
+        empty2: false
+        empty3: undefined
+      result = getArguments(args)
+      expect(result.length).toEqual(2)
+      expect(result[0]).toEqual('--foo=bar')
+      expect(result[1]).toEqual('--none=lala')
+
+    it 'should load user arguments', ->
+      atom.config.set 'markdown-preview-plus.pandocArguments',
+        ['-v', '--smart', 'rem', '--filter=/foo/bar', '--filter-foo /foo/baz']
+      args = {}
+      result = getArguments(args)
+      expect(result.length).toEqual(4)
+      expect(result[0]).toEqual('-v')
+      expect(result[1]).toEqual('--smart')
+      expect(result[2]).toEqual('--filter=/foo/bar')
+      expect(result[3]).toEqual('--filter-foo=/foo/baz')
+
+    it 'should combine user arguments and given arguments', ->
+      atom.config.set 'markdown-preview-plus.pandocArguments',
+        ['-v', '--filter-foo /foo/baz']
+      args =
+        foo: 'bar'
+        empty3: undefined
+      result = getArguments(args)
+      expect(result.length).toEqual(3)
+      expect(result[0]).toEqual('--foo=bar')
+      expect(result[1]).toEqual('-v')
+      expect(result[2]).toEqual('--filter-foo=/foo/baz')
+
+
+  describe "PandocHelper::setPandocOptions", ->
+    fallBackBib = '/foo/fallback.bib'
+    fallBackCsl = '/foo/fallback.csl'
+    setPandocOptions = pandocHelper.__testing__.setPandocOptions
+
+
+    beforeEach ->
+      file = path.join tempPath, 'subdir', 'simple.md'
+      atom.config.set 'markdown-preview-plus.pandocBibliography', true
+      atom.config.set 'markdown-preview-plus.pandocBIBFile', bibFile
+      atom.config.set 'markdown-preview-plus.pandocBIBFileFallback', fallBackBib
+      atom.config.set 'markdown-preview-plus.pandocCSLFile', cslFile
+      atom.config.set 'markdown-preview-plus.pandocCSLFileFallback', fallBackCsl
+
+    it "shouldn't set pandoc bib options if citations are disabled", ->
+      runs ->
+        atom.config.set 'markdown-preview-plus.pandocBibliography', false
+        fs.writeFileSync path.join(tempPath, bibFile), ''
+        config = setPandocOptions file
+        expect(config.args.bibliography).toEqual(undefined)
+
+    it "shouldn't set pandoc bib options if no fallback file exists", ->
+      runs ->
+        atom.config.set 'markdown-preview-plus.pandocBIBFileFallback'
+        config = setPandocOptions file
+        expect(config.args.bibliography).toEqual(undefined)
+
+    it "should set pandoc bib options if citations are enabled and project bibFile exists", ->
+      runs ->
+        bibPath = path.join(tempPath, bibFile)
+        fs.writeFileSync bibPath, ''
+        config = setPandocOptions file
+        expect(config.args.bibliography).toEqual(bibPath)
+
+    it "should set pandoc bib options if citations are enabled and use fallback", ->
+      runs ->
+        config = setPandocOptions file
+        expect(config.args.bibliography).toEqual(fallBackBib)
+
+    it "shouldn't set pandoc csl options if citations are disabled", ->
+      runs ->
+        atom.config.set 'markdown-preview-plus.pandocBibliography', false
+        fs.writeFileSync path.join(tempPath, cslFile), ''
+        config = setPandocOptions file
+        expect(config.args.csl).toEqual(undefined)
+
+    it "shouldn't set pandoc csl options if no fallback file exists", ->
+      runs ->
+        atom.config.set 'markdown-preview-plus.pandocCSLFileFallback'
+        config = setPandocOptions file
+        expect(config.args.csl).toEqual(undefined)
+
+    it "should set pandoc csl options if citations are enabled and project cslFile exists", ->
+      runs ->
+        cslPath = path.join(tempPath, cslFile)
+        fs.writeFileSync cslPath, ''
+        config = setPandocOptions file
+        expect(config.args.csl).toEqual(cslPath)
+
+    it "should set pandoc csl options if citations are enabled and use fallback", ->
+      runs ->
+        config = setPandocOptions file
+        expect(config.args.csl).toEqual(fallBackCsl)


### PR DESCRIPTION
If no local bibfile/cslfile is found, a fallback file is used if provided.

Fixes #50, replaces #62 