### PR TITLE
[feat] deactivated failing tests on wercker (and only on wercker)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "wrench": "^1.5.0"
   },
   "devDependencies": {
-    "coffeelint": "^1.9.7"
+    "coffeelint": "^1.9.7",
+    "jasmine-tagged": "^1.1.4"
   }
 }

--- a/spec/markdown-preview-pandoc-helper-spec.coffee
+++ b/spec/markdown-preview-pandoc-helper-spec.coffee
@@ -11,6 +11,8 @@ cslFile = 'foo.csl'
 tempPath = null
 file = null
 
+require './spec-helper'
+
 describe "Markdown preview plus pandoc helper", ->
   [workspaceElement, preview] = []
 

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -5,6 +5,8 @@ wrench = require 'wrench'
 MarkdownPreviewView = require '../lib/markdown-preview-view'
 {$} = require 'atom-space-pen-views'
 
+require './spec-helper'
+
 describe "Markdown preview plus package", ->
   [workspaceElement, preview] = []
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -6,6 +6,8 @@ pathWatcher = require 'pathwatcher'
 url = require 'url'
 queryString = require 'querystring'
 
+require './spec-helper'
+
 describe "MarkdownPreviewView", ->
   [file, preview, workspaceElement] = []
 
@@ -199,7 +201,7 @@ describe "MarkdownPreviewView", ->
           imageVer = getImageVersion(img1Path, imageURL)
           expect(imageVer).not.toEqual('deleted')
 
-    describe "when a local image is modified during a preview", ->
+    describe "when a local image is modified during a preview #notwercker", ->
       it "rerenders the image with a more recent timestamp query", ->
         [imageURL, imageVer] = []
 
@@ -223,7 +225,7 @@ describe "MarkdownPreviewView", ->
           expect(newImageVer).not.toEqual('deleted')
           expect(parseInt(newImageVer)).toBeGreaterThan(parseInt(imageVer))
 
-    describe "when three images are previewed and all are modified", ->
+    describe "when three images are previewed and all are modified #notwercker", ->
       it "rerenders the images with a more recent timestamp as they are modified", ->
         [img2Path, img3Path] = []
         [img1Ver, img2Ver, img3Ver] = []

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -1,0 +1,13 @@
+require 'jasmine-tagged'
+
+_ = require 'underscore-plus'
+
+tags = [process.platform]
+
+tags.push('notwercker') unless process.env.WERCKER_ROOT
+
+jasmineEnv = jasmine.getEnv()
+original = jasmineEnv.setIncludedTags
+
+jasmineEnv.setIncludedTags = (t) ->
+  original(_.union tags, t)


### PR DESCRIPTION
fixes #65.

It seems like wercker is using a filesystem which does not support all features of inotfiy (linux kernel feature), especially file changes.

inotify is used by pathwatcher.

I deactivated the tests not working on wercker and only there
