### PR TITLE
Add appveyor matrix and caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ notifications:
 env:
   - APM_TEST_PACKAGES="mathjax-wrapper"
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script:
+  - '(curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh) || true'
+  - './node_modules/.bin/coffeelint lib'
+  - './node_modules/.bin/coffeelint spec'
+  - 'ATOM_PATH=./atom atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm test --path atom/Atom.app/Contents/Resources/app/atom.sh'
 
 git:
   depth: 10

--- a/README.md
+++ b/README.md
@@ -23,14 +23,17 @@ We also have a more detailed description of [features][features].
 
 Long instructions can be found [here][installation]. In short steps:
 
-1.  Make sure node-gyp is [installed correctly][node-gyp].
+1.  Make sure node-gyp is [installed correctly][node-gyp] with a python 2.7 version (and Visual Studio 2012 or 2013 if you are on Windows). 
 
 2.  Install this package and [`mathjax-wrapper`][mathjax-wrapper]
-    for math rendering:
+    for math rendering. Installation of mathjax-wrapper may take a long time.
 
     ``` bash
-    apm install mathjax-wrapper markdown-preview-plus
+    apm install mathjax-wrapper
+    apm install markdown-preview-plus
     ```
+
+    If you have issues installing on Windows, please [check here for help][win-install]
 
 3.  Disable built-in package  *Markdown Preview*
 
@@ -50,6 +53,7 @@ Markdown Preview Plus (MPP) is released under the [MIT license][license].
 
 [issue]: https://github.com/Galadirith/markdown-preview-plus/issues
 [installation]: docs/installation.md
+[win-install]: docs/win-install.md
 [license]: LICENSE.md
 [math]: docs/math.md
 [features]: docs/features.md

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,14 @@
 version: "{build}"
 os: Windows Server 2012 R2
-matrix:
-  #- GYP_MSVS_VERSION: 2008
-  #   os: Windows Server 2012 R2
-  #- GYP_MSVS_VERSION: 2010
-  #   os: Windows Server 2012 R2
-  - GYP_MSVS_VERSION: 2012
-  #   os: Windows Server 2012 R2
-  - GYP_MSVS_VERSION: 2013
+environment:
+  matrix:
+    #- GYP_MSVS_VERSION: 2008
+    #   os: Windows Server 2012 R2
+    #- GYP_MSVS_VERSION: 2010
+    #   os: Windows Server 2012 R2
+    - GYP_MSVS_VERSION: 2012
+    #   os: Windows Server 2012 R2
+    - GYP_MSVS_VERSION: 2013
 build: off
 deploy: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ cache:
 
 install:
   - cd %LOCALAPPDATA%
-  - (New-Object Net.WebClient).DownloadFile("https://github.com/atom/atom/releases/download/$((Invoke-RestMethod -Method Get -Uri 'http://latest-atom-version.xyz/').trim())/atom-windows.zip", "$(pwd)\atom-windows.zip")
+  - ps: (New-Object Net.WebClient).DownloadFile("https://github.com/atom/atom/releases/download/$((Invoke-RestMethod -Method Get -Uri 'http://latest-atom-version.xyz/').trim())/atom-windows.zip", "$(pwd)\atom-windows.zip")
   - 7z -y x atom-windows.zip > nul
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,16 +2,8 @@ version: "{build}"
 os: Visual Studio 2015
 environment:
   matrix:
-    - GYP_MSVS_VERSION: 2008
-    - GYP_MSVS_VERSION: 2010
     - GYP_MSVS_VERSION: 2012
     - GYP_MSVS_VERSION: 2013
-    - GYP_MSVS_VERSION: 2015
-
-matrix:
-  allow_failures:
-    - GYP_MSVS_VERSION: 2008
-    - GYP_MSVS_VERSION: 2010
 
 build: off
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ install:
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
   - ps: |
-      Write-Host %USERPROFILE%\.atom\packages\mathjax-wrapper\package.json
-      If (Test-Path %USERPROFILE%\.atom\packages\mathjax-wrapper\package.json){
+      Write-Host $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json
+      If (Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json){
         Write-Host "Atom mathjax-wrapper already installed"
       }Else{
         apm install mathjax-wrapper

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,26 @@
 version: "{build}"
 os: Windows Server 2012 R2
-
-test: off
+matrix:
+  #- GYP_MSVS_VERSION: 2008
+  #   os: Windows Server 2012 R2
+  #- GYP_MSVS_VERSION: 2010
+  #   os: Windows Server 2012 R2
+  - GYP_MSVS_VERSION: 2012
+  #   os: Windows Server 2012 R2
+  - GYP_MSVS_VERSION: 2013
+build: off
 deploy: off
 
 install:
-  - cmd: cd %LOCALAPPDATA%
+  - cd %LOCALAPPDATA%
   - ps: (New-Object Net.WebClient).DownloadFile("https://github.com/atom/atom/releases/download/$((Invoke-RestMethod -Method Get -Uri 'http://latest-atom-version.xyz/' ).trim())/atom-windows.zip", "$(pwd)\atom-windows.zip")
-  - cmd: 7z -y x atom-windows.zip > nul
+  - 7z -y x atom-windows.zip > nul
+  - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
+  - apm --version
+  - apm install mathjax-wrapper
 
-build_script:
-  - cmd: SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
-  - cmd: cd %APPVEYOR_BUILD_FOLDER%
-  - cmd: apm clean
-  - cmd: apm install
-  - cmd: apm install mathjax-wrapper
-  - cmd: apm test --one --path %LOCALAPPDATA%\Atom\resources\cli\atom.cmd
+test_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - apm clean
+  - apm install
+  - apm test --one --path %LOCALAPPDATA%\Atom\resources\cli\atom.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,18 @@
 version: "{build}"
-os: Windows Server 2012 R2
+os: Visual Studio 2015
 environment:
   matrix:
-    #- GYP_MSVS_VERSION: 2008
-    #   os: Windows Server 2012 R2
-    #- GYP_MSVS_VERSION: 2010
-    #   os: Windows Server 2012 R2
+    - GYP_MSVS_VERSION: 2008
+    - GYP_MSVS_VERSION: 2010
     - GYP_MSVS_VERSION: 2012
-    #   os: Windows Server 2012 R2
     - GYP_MSVS_VERSION: 2013
+    - GYP_MSVS_VERSION: 2015
+
+matrix:
+  allow_failures:
+    - GYP_MSVS_VERSION: 2008
+    - GYP_MSVS_VERSION: 2010
+
 build: off
 deploy: off
 
@@ -22,7 +26,6 @@ install:
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
   - ps: |
-      Write-Host $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json
       If (Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json){
         Write-Host "Atom mathjax-wrapper already installed"
       }Else{

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
   - ps: |
-      If (Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json -And Test-Path $env:USERPROFILE\mathjax.version){
+      If ((Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json) -And (Test-Path $env:USERPROFILE\mathjax.version)){
         apm show mathjax-wrapper > $env:USERPROFILE\mathjax-new.version
         If ((Get-FileHash $env:USERPROFILE\mathjax.version).hash -ne (Get-FileHash $env:USERPROFILE\mathjax-new.version).hash){
           Remove-Item $env:USERPROFILE\.atom\packages\mathjax-wrapper -recurse -Force

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,22 @@ environment:
 build: off
 deploy: off
 
+cache:
+  - %USERPROFILE%\.atom\packages\mathjax-wrapper -> package.json
+
 install:
   - cd %LOCALAPPDATA%
-  - ps: (New-Object Net.WebClient).DownloadFile("https://github.com/atom/atom/releases/download/$((Invoke-RestMethod -Method Get -Uri 'http://latest-atom-version.xyz/' ).trim())/atom-windows.zip", "$(pwd)\atom-windows.zip")
+  - (New-Object Net.WebClient).DownloadFile("https://github.com/atom/atom/releases/download/$((Invoke-RestMethod -Method Get -Uri 'http://latest-atom-version.xyz/').trim())/atom-windows.zip", "$(pwd)\atom-windows.zip")
   - 7z -y x atom-windows.zip > nul
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
-  - apm install mathjax-wrapper
+  - ps: |
+  If (Test-Path %USERPROFILE%\.atom\packages\mathjax-wrapper){
+    Write-Host "Atom mathjax-wrapper already installed"
+  }Else{
+    apm install mathjax-wrapper
+  }
+
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,7 @@ install:
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
   - ps: |
-      If (
-        Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json
-        -And Test-Path $env:USERPROFILE\mathjax.version
-        ){
+      If (Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json -And Test-Path $env:USERPROFILE\mathjax.version){
         apm show mathjax-wrapper > $env:USERPROFILE\mathjax-new.version
         If ((Get-FileHash $env:USERPROFILE\mathjax.version).hash -ne (Get-FileHash $env:USERPROFILE\mathjax-new.version).hash){
           Remove-Item $env:USERPROFILE\.atom\packages\mathjax-wrapper -recurse -Force

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,8 @@ build: off
 deploy: off
 
 cache:
-  - C:\Users\appveyor\.atom\packages\mathjax-wrapper -> package.json
+  - C:\Users\appveyor\.atom\packages\mathjax-wrapper
+  - C:\Users\appveyor\mathjax.version
 
 install:
   - cd %LOCALAPPDATA%
@@ -17,6 +18,17 @@ install:
   - 7z -y x atom-windows.zip > nul
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
+  - ps: |
+      If (
+        Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json
+        -And Test-Path $env:USERPROFILE\mathjax.version
+        ){
+        apm show mathjax-wrapper > $env:USERPROFILE\mathjax-new.version
+        If ((Get-FileHash $env:USERPROFILE\mathjax.version).hash -ne (Get-FileHash $env:USERPROFILE\mathjax-new.version).hash){
+          Remove-Item $env:USERPROFILE\.atom\packages\mathjax-wrapper -recurse -Force
+        }
+      }
+      apm show mathjax-wrapper > $env:USERPROFILE\mathjax.version
   - ps: |
       If (Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json){
         Write-Host "Atom mathjax-wrapper already installed"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,8 @@ install:
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
   - ps: |
-      If (Test-Path %USERPROFILE%\.atom\packages\mathjax-wrapper){
+      Write-Host %USERPROFILE%\.atom\packages\mathjax-wrapper\package.json
+      If (Test-Path %USERPROFILE%\.atom\packages\mathjax-wrapper\package.json){
         Write-Host "Atom mathjax-wrapper already installed"
       }Else{
         apm install mathjax-wrapper

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build: off
 deploy: off
 
 cache:
-  - %USERPROFILE%\.atom\packages\mathjax-wrapper -> package.json
+  - C:\Users\appveyor\.atom\packages\mathjax-wrapper -> package.json
 
 install:
   - cd %LOCALAPPDATA%
@@ -22,12 +22,11 @@ install:
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%PATH%
   - apm --version
   - ps: |
-  If (Test-Path %USERPROFILE%\.atom\packages\mathjax-wrapper){
-    Write-Host "Atom mathjax-wrapper already installed"
-  }Else{
-    apm install mathjax-wrapper
-  }
-
+      If (Test-Path %USERPROFILE%\.atom\packages\mathjax-wrapper){
+        Write-Host "Atom mathjax-wrapper already installed"
+      }Else{
+        apm install mathjax-wrapper
+      }
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/docs/win-install.md
+++ b/docs/win-install.md
@@ -1,0 +1,40 @@
+# Windows installation problems
+
+Before you post a issue that this package cannot be installed, please execute `apm --version`, it should return something like:
+
+``` bash
+apm --version
+apm  1.0.1
+npm  2.5.1
+node 0.10.35
+python 2.7.9
+git 1.9.5.msysgit.0
+visual studio 2012
+```
+
+Please make sure that you are using `python 2.*` and `visual studio 2012` or `visual studio 2013`, all python versions >= 3 will fail, also visual studio versions 2008, 2010 and 2015.
+
+The `node-gyp` [installation section][install-gyp] contains links and instructions for installation of python and Visual Studio.
+
+If you have multiple versions of python installed you can set the path to python 2.7 with:
+`
+npm config set python "C:\path\to\python2.7"
+`
+
+If you have installed visual studio 2012 or 2013, set the following variable accordingly.
+
+```bash
+set GYP_MSVS_VERSION=2012
+# or
+set GYP_MSVS_VERSION=2013
+```
+
+The ourput of `apm --version` should now look like the the one at the top of this page. Now try running `apm install markdown-preview-plus` again.
+
+If something still fails, please open an [issue][issue] and paste the output of both:
+
+*   `apm --version`
+*   `apm install markdown-preview-plus`
+
+[issue]: https://github.com/Galadirith/markdown-preview-plus/issues
+[install-gyp]: https://github.com/nodejs/node-gyp#installation


### PR DESCRIPTION
Added appveyor test matrix for Visual Studio 2012 and 2013.
Other Versions of VS [seem to be failing](https://ci.appveyor.com/project/Galadirith/markdown-preview-plus/build/45).

Furthermore enabled caching of mathjax-wrapper, which reduces build times from ~11 min to ~5 min.
The mathjax-wrapper cache will be deleted once there is a new mathjax-wrapper version pushed.

Added documentation as per discussion in #69.