### PR TITLE
[WIP] Sync source and preview on demand

### DIFF
--- a/lib/markdown-it-helper.coffee
+++ b/lib/markdown-it-helper.coffee
@@ -53,3 +53,7 @@ exports.render = (text, rL) ->
 
 exports.decode = (url) ->
   markdownIt.normalizeLinkText url
+
+exports.getTokens = (text, rL) ->
+  init(rL) if needsInit(rL)
+  markdownIt.parse text

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -113,20 +113,6 @@ class MarkdownPreviewView extends ScrollView
           return unless source?
           @syncSource source, event.target
 
-    @on 'click', (event) =>
-      return unless event.altKey is true
-      @getMarkdownSource().then (source) =>
-        return unless source?
-        @syncSource source, event.target
-
-    @on 'keydown', (event) =>
-      return unless event.which is 18
-      return false
-
-    @on 'keyup', (event) =>
-      return unless event.which is 18
-      return false
-
     changeHandler = =>
       @renderMarkdown()
 

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -486,7 +486,7 @@ class MarkdownPreviewView extends ScrollView
             level++
           else
             pathToElement[0].index--
-        else if token.nesting is 0 and token.tag in ['math', 'code']
+        else if token.nesting is 0 and token.tag in ['math', 'code', 'hr']
           if pathToElement[0].index is 0
             finalToken = token
             break

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -113,6 +113,20 @@ class MarkdownPreviewView extends ScrollView
           return unless source?
           @syncSource source, event.target
 
+    @on 'click', (event) =>
+      return unless event.altKey is true
+      @getMarkdownSource().then (source) =>
+        return unless source?
+        @syncSource source, event.target
+
+    @on 'keydown', (event) =>
+      return unless event.which is 18
+      return false
+
+    @on 'keyup', (event) =>
+      return unless event.which is 18
+      return false
+
     changeHandler = =>
       @renderMarkdown()
 

--- a/menus/markdown-preview.cson
+++ b/menus/markdown-preview.cson
@@ -15,7 +15,10 @@
 ]
 
 'context-menu':
+  'atom-workspace atom-text-editor[data-grammar*="gfm"]':
+    [{label: 'Sync Preview', command: 'markdown-preview-plus:sync-preview'}]
   '.markdown-preview': [
+    {label: 'Sync Source', command: 'markdown-preview-plus:sync-source'}
     {label: 'Copy As HTML', command: 'core:copy'}
     {label: 'Save As HTML\u2026', command: 'core:save-as'}
   ]

--- a/spec/fixtures/sync-preview.cson
+++ b/spec/fixtures/sync-preview.cson
@@ -1,0 +1,3612 @@
+[
+  {
+    line: 0
+    path: [
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 1
+    path: []
+  }
+  {
+    line: 2
+    path: [
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 3
+    path: []
+  }
+  {
+    line: 4
+    path: [
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 5
+    path: [
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 6
+    path: [
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 7
+    path: []
+  }
+  {
+    line: 8
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 9
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 10
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 11
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 12
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 13
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 14
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 15
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 16
+    path: []
+  }
+  {
+    line: 17
+    path: [
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 18
+    path: []
+  }
+  {
+    line: 19
+    path: [
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 20
+    path: [
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 21
+    path: [
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 22
+    path: []
+  }
+  {
+    line: 23
+    path: [
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 24
+    path: [
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 25
+    path: [
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 26
+    path: [
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 27
+    path: [
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 28
+    path: []
+  }
+  {
+    line: 29
+    path: [
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 30
+    path: []
+  }
+  {
+    line: 31
+    path: [
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 32
+    path: [
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 33
+    path: [
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 34
+    path: [
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 35
+    path: [
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 36
+    path: [
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 37
+    path: [
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 38
+    path: [
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 39
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 40
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 41
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 42
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 43
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 44
+    path: []
+  }
+  {
+    line: 45
+    path: [
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 46
+    path: [
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 47
+    path: [
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 48
+    path: []
+  }
+  {
+    line: 49
+    path: [
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 50
+    path: [
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 51
+    path: [
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 52
+    path: []
+  }
+  {
+    line: 53
+    path: [
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 54
+    path: [
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 55
+    path: []
+  }
+  {
+    line: 56
+    path: [
+      {
+        tag: "h1"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 57
+    path: []
+  }
+  {
+    line: 58
+    path: [
+      {
+        tag: "p"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 59
+    path: []
+  }
+  {
+    line: 60
+    path: [
+      {
+        tag: "p"
+        index: 5
+      }
+    ]
+  }
+  {
+    line: 61
+    path: [
+      {
+        tag: "p"
+        index: 5
+      }
+    ]
+  }
+  {
+    line: 62
+    path: [
+      {
+        tag: "p"
+        index: 5
+      }
+    ]
+  }
+  {
+    line: 63
+    path: []
+  }
+  {
+    line: 64
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 65
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 66
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 67
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 68
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 69
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 70
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 71
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 72
+    path: []
+  }
+  {
+    line: 73
+    path: [
+      {
+        tag: "blockquote"
+        index: 2
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 74
+    path: []
+  }
+  {
+    line: 75
+    path: [
+      {
+        tag: "blockquote"
+        index: 3
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 76
+    path: [
+      {
+        tag: "blockquote"
+        index: 3
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 77
+    path: [
+      {
+        tag: "blockquote"
+        index: 3
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 78
+    path: []
+  }
+  {
+    line: 79
+    path: [
+      {
+        tag: "span"
+        index: 3
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 80
+    path: [
+      {
+        tag: "span"
+        index: 3
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 81
+    path: [
+      {
+        tag: "span"
+        index: 3
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 82
+    path: [
+      {
+        tag: "span"
+        index: 3
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 83
+    path: [
+      {
+        tag: "span"
+        index: 3
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 84
+    path: []
+  }
+  {
+    line: 85
+    path: [
+      {
+        tag: "hr"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 86
+    path: []
+  }
+  {
+    line: 87
+    path: [
+      {
+        tag: "ul"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 88
+    path: [
+      {
+        tag: "ul"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 89
+    path: [
+      {
+        tag: "ul"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 90
+    path: [
+      {
+        tag: "ul"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 91
+    path: [
+      {
+        tag: "ol"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 92
+    path: [
+      {
+        tag: "ol"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 93
+    path: [
+      {
+        tag: "ol"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 94
+    path: [
+      {
+        tag: "ol"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 95
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 96
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 97
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 98
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 99
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 100
+    path: []
+  }
+  {
+    line: 101
+    path: [
+      {
+        tag: "span"
+        index: 4
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 102
+    path: [
+      {
+        tag: "span"
+        index: 4
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 103
+    path: [
+      {
+        tag: "span"
+        index: 4
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 104
+    path: []
+  }
+  {
+    line: 105
+    path: [
+      {
+        tag: "span"
+        index: 5
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 106
+    path: [
+      {
+        tag: "span"
+        index: 5
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 107
+    path: [
+      {
+        tag: "span"
+        index: 5
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 108
+    path: []
+  }
+  {
+    line: 109
+    path: [
+      {
+        tag: "p"
+        index: 7
+      }
+    ]
+  }
+  {
+    line: 110
+    path: [
+      {
+        tag: "p"
+        index: 7
+      }
+    ]
+  }
+  {
+    line: 111
+    path: [
+      {
+        tag: "p"
+        index: 7
+      }
+    ]
+  }
+  {
+    line: 112
+    path: []
+  }
+  {
+    line: 113
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 114
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 115
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 116
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 117
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 118
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 119
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 120
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 121
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 122
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 123
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 124
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 125
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 126
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 127
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 128
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 129
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 130
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 131
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 132
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 133
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 134
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 135
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 136
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 137
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 138
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 139
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 140
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 141
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 142
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 143
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 144
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 145
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 146
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 147
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 148
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 149
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 150
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 151
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 152
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 153
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 154
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 155
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 156
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 157
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 158
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 159
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 160
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 161
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 162
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 163
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 164
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 165
+    path: []
+  }
+  {
+    line: 166
+    path: [
+      {
+        tag: "p"
+        index: 8
+      }
+    ]
+  }
+  {
+    line: 167
+    path: []
+  }
+  {
+    line: 168
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 169
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 170
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 171
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 172
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 173
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 174
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 175
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 176
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 177
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 178
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 179
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 180
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 181
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 182
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 183
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 184
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 185
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 186
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 187
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 188
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 189
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 190
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 191
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 192
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 193
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 194
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 195
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 196
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 197
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 198
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 199
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 200
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 201
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 202
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 203
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 204
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 205
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 206
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 207
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 208
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 209
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 210
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 211
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 212
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 213
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 214
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 215
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 216
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 217
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 218
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 219
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 220
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 221
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 222
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 223
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 224
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 225
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 226
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 227
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 228
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 229
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 230
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 231
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 232
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 233
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 234
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 235
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 236
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 237
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 238
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 239
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 240
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 241
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 242
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 243
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 244
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 245
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 246
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 247
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 248
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 249
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 250
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 251
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 252
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 253
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 254
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 255
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 256
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 257
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 258
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 259
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 260
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 261
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 262
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 263
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 264
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 265
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 266
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 267
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 268
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 269
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 270
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 271
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 272
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 273
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 274
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 275
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 276
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 277
+    path: []
+  }
+]

--- a/spec/fixtures/sync-source.cson
+++ b/spec/fixtures/sync-source.cson
@@ -1,0 +1,1548 @@
+[
+  {
+    line: 0
+    path: [
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 2
+    path: [
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 4
+    path: [
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 8
+    path: [
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 17
+    path: [
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 19
+    path: [
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 23
+    path: [
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 29
+    path: [
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 31
+    path: [
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 32
+    path: [
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 33
+    path: [
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 35
+    path: [
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 36
+    path: [
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 37
+    path: [
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 39
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 39
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "thead"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 41
+    path: [
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "tbody"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 45
+    path: [
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 49
+    path: [
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 53
+    path: [
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 56
+    path: [
+      {
+        tag: "h1"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 58
+    path: [
+      {
+        tag: "p"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 60
+    path: [
+      {
+        tag: "p"
+        index: 5
+      }
+    ]
+  }
+  {
+    line: 64
+    path: [
+      {
+        tag: "p"
+        index: 6
+      }
+    ]
+  }
+  {
+    line: 73
+    path: [
+      {
+        tag: "blockquote"
+        index: 2
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 75
+    path: [
+      {
+        tag: "blockquote"
+        index: 3
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 79
+    path: [
+      {
+        tag: "span"
+        index: 3
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 85
+    path: [
+      {
+        tag: "hr"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 87
+    path: [
+      {
+        tag: "ul"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 88
+    path: [
+      {
+        tag: "ul"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 89
+    path: [
+      {
+        tag: "ul"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 91
+    path: [
+      {
+        tag: "ol"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 92
+    path: [
+      {
+        tag: "ol"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 93
+    path: [
+      {
+        tag: "ol"
+        index: 1
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 95
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 95
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+      {
+        tag: "thead"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 97
+    path: [
+      {
+        tag: "table"
+        index: 1
+      }
+      {
+        tag: "tbody"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 101
+    path: [
+      {
+        tag: "span"
+        index: 4
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 105
+    path: [
+      {
+        tag: "span"
+        index: 5
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 109
+    path: [
+      {
+        tag: "p"
+        index: 7
+      }
+    ]
+  }
+  {
+    line: 113
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+    ]
+  }
+  {
+    line: 113
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 115
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 117
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 121
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 130
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 132
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 136
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 142
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 144
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 145
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 146
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 148
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 149
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 150
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 152
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 152
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "thead"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 154
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "tbody"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 158
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 162
+    path: [
+      {
+        tag: "blockquote"
+        index: 4
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 166
+    path: [
+      {
+        tag: "p"
+        index: 8
+      }
+    ]
+  }
+  {
+    line: 168
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 168
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 170
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 172
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 174
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 178
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 187
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 189
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 193
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 199
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 201
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 202
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 203
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 205
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 206
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 207
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 209
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 209
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "thead"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 211
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "tbody"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 215
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 219
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 223
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 223
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 225
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "h1"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 227
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 229
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 233
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 3
+      }
+    ]
+  }
+  {
+    line: 242
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "blockquote"
+        index: 0
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 244
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "blockquote"
+        index: 1
+      }
+      {
+        tag: "p"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 248
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 0
+        class: "atom-text-editor"
+      }
+    ]
+  }
+  {
+    line: 254
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "hr"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 256
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 257
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 258
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ul"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 260
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 261
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+    ]
+  }
+  {
+    line: 262
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "ol"
+        index: 0
+      }
+      {
+        tag: "li"
+        index: 2
+      }
+    ]
+  }
+  {
+    line: 264
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 264
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "thead"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 266
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "table"
+        index: 0
+      }
+      {
+        tag: "tbody"
+        index: 0
+      }
+    ]
+  }
+  {
+    line: 270
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 1
+        class: "math"
+      }
+    ]
+  }
+  {
+    line: 274
+    path: [
+      {
+        tag: "ul"
+        index: 2
+      }
+      {
+        tag: "li"
+        index: 1
+      }
+      {
+        tag: "span"
+        index: 2
+        class: "math"
+      }
+    ]
+  }
+]

--- a/spec/fixtures/sync.md
+++ b/spec/fixtures/sync.md
@@ -1,0 +1,277 @@
+# heading
+
+This is a paragraph
+
+This is a
+multi-line
+paragraph
+
+This is a paragraph that contains inline elements
+such as inline maths $E=mc^2$ which can also be written as \(E=mc^2\) and
+inline code `like this` and
+italic text *like this* and
+bold text **like this** and
+links [like this](http://github.com/galadirith/markdown-preview-plus) and
+images ![like this](subdir/image1.png) and
+strike through ~~like this~~.
+
+> This is a block quote
+
+> This is a
+> multi-line
+> blockquote
+
+```
+This is a
+fenced
+codeblock
+```
+
+---
+
+- Unordered 1
+- Unordered 2
+- Unordered 3
+
+1. Ordered 1
+2. Ordered 2
+3. Ordered 3
+
+| Column 1 | Column 2 | Column 3 |
+| -------- |--------- | ---------|
+| This     | is       | a        |
+| table    | with     | three    |
+| columns  | four     | rows     |
+
+$$
+\int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+$$
+
+\[
+\int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+\]
+
+We'll repeat everything to make sure the sync parser is correctly identifying
+siblings with the same tag.
+
+# heading
+
+This is a paragraph
+
+This is a
+multi-line
+paragraph
+
+This is a paragraph that contains inline elements
+such as inline maths $E=mc^2$ which can also be written as \(E=mc^2\) and
+inline code `like this` and
+italic text *like this* and
+bold text **like this** and
+links [like this](http://github.com/galadirith/markdown-preview-plus) and
+images ![like this](subdir/image1.png) and
+strike through ~~like this~~.
+
+> This is a block quote
+
+> This is a
+> multi-line
+> blockquote
+
+```
+This is a
+fenced
+codeblock
+```
+
+---
+
+- Unordered 1
+- Unordered 2
+- Unordered 3
+
+1. Ordered 1
+2. Ordered 2
+3. Ordered 3
+
+| Column 1 | Column 2 | Column 3 |
+| -------- |--------- | ---------|
+| This     | is       | a        |
+| table    | with     | three    |
+| columns  | four     | rows     |
+
+$$
+\int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+$$
+
+\[
+\int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+\]
+
+Now we'll consider embedding block level elements in
+[container blocks](http://spec.commonmark.org/0.21/#container-blocks). First
+we'll consider embedding in block quotes.
+
+> # heading
+>
+> This is a paragraph
+>
+> This is a
+> multi-line
+> paragraph
+>
+> This is a paragraph that contains inline elements
+> such as inline maths $E=mc^2$ which can also be written as \(E=mc^2\) and
+> inline code `like this` and
+> italic text *like this* and
+> bold text **like this** and
+> links [like this](http://github.com/galadirith/markdown-preview-plus) and
+> images ![like this](subdir/image1.png) and
+> strike through ~~like this~~.
+>
+> > This is a block quote
+>
+> > This is a
+> > multi-line
+> > blockquote
+>
+> ```
+> This is a
+> fenced
+> codeblock
+> ```
+>
+> ---
+>
+> - Unordered 1
+> - Unordered 2
+> - Unordered 3
+>
+> 1. Ordered 1
+> 2. Ordered 2
+> 3. Ordered 3
+>
+> | Column 1 | Column 2 | Column 3 |
+> | -------- |--------- | ---------|
+> | This     | is       | a        |
+> | table    | with     | three    |
+> | columns  | four     | rows     |
+>
+> $$
+> \int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+> $$
+>
+> \[
+> \int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+> \]
+
+Now we'll consider embedding in lists.
+
+- item 1
+
+  # heading
+
+  This is a paragraph
+
+  This is a
+  multi-line
+  paragraph
+
+  This is a paragraph that contains inline elements
+  such as inline maths $E=mc^2$ which can also be written as \(E=mc^2\) and
+  inline code `like this` and
+  italic text *like this* and
+  bold text **like this** and
+  links [like this](http://github.com/galadirith/markdown-preview-plus) and
+  images ![like this](subdir/image1.png) and
+  strike through ~~like this~~.
+
+  > This is a block quote
+
+  > This is a
+  > multi-line
+  > blockquote
+
+  ```
+  This is a
+  fenced
+  codeblock
+  ```
+
+  ---
+
+  - Unordered 1
+  - Unordered 2
+  - Unordered 3
+
+  1. Ordered 1
+  2. Ordered 2
+  3. Ordered 3
+
+  | Column 1 | Column 2 | Column 3 |
+  | -------- |--------- | ---------|
+  | This     | is       | a        |
+  | table    | with     | three    |
+  | columns  | four     | rows     |
+
+  $$
+  \int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+  $$
+
+  \[
+  \int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+  \]
+
+- item 2
+
+  # heading
+
+  This is a paragraph
+
+  This is a
+  multi-line
+  paragraph
+
+  This is a paragraph that contains inline elements
+  such as inline maths $E=mc^2$ which can also be written as \(E=mc^2\) and
+  inline code `like this` and
+  italic text *like this* and
+  bold text **like this** and
+  links [like this](http://github.com/galadirith/markdown-preview-plus) and
+  images ![like this](subdir/image1.png) and
+  strike through ~~like this~~.
+
+  > This is a block quote
+
+  > This is a
+  > multi-line
+  > blockquote
+
+  ```
+  This is a
+  fenced
+  codeblock
+  ```
+
+  ---
+
+  - Unordered 1
+  - Unordered 2
+  - Unordered 3
+
+  1. Ordered 1
+  2. Ordered 2
+  3. Ordered 3
+
+  | Column 1 | Column 2 | Column 3 |
+  | -------- |--------- | ---------|
+  | This     | is       | a        |
+  | table    | with     | three    |
+  | columns  | four     | rows     |
+
+  $$
+  \int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+  $$
+
+  \[
+  \int_{-\infty}^\infty e^{-x^2} = \sqrt{\pi}
+  \]

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -1,0 +1,110 @@
+{$}           = require 'atom-space-pen-views'
+path          = require 'path'
+temp          = require('temp').track()
+cson          = require 'season'
+markdownIt    = require '../lib/markdown-it-helper'
+mathjaxHelper = require '../lib/mathjax-helper'
+MarkdownPreviewView = require '../lib/markdown-preview-view'
+
+describe "Syncronization of source and preview", ->
+  [preview, workspaceElement, fixturesPath] = []
+
+  beforeEach ->
+    fixturesPath = path.join(__dirname, 'fixtures')
+
+    # Setup Jasmine environment
+    jasmine.useRealClock() # MathJax queue's will NOT work without this
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM workspaceElement
+
+    # Redirect atom to a temp config directory
+    configDirPath = temp.mkdirSync('atom-config-dir-')
+    spyOn(atom, 'getConfigDirPath').andReturn configDirPath
+
+    waitsForPromise ->
+      atom.packages.activatePackage("mathjax-wrapper")
+
+    waitsForPromise ->
+      atom.packages.activatePackage("markdown-preview-plus")
+
+    waitsFor "MathJax to load", ->
+      MathJax?
+
+    waitsFor "LaTeX rendering to be enabled", ->
+      atom.config.set 'markdown-preview-plus.enableLatexRenderingByDefault', true
+
+    waitsForPromise ->
+      atom.workspace.open path.join(fixturesPath, 'sync.md')
+
+    runs ->
+      spyOn(mathjaxHelper, 'mathProcessor').andCallThrough()
+      atom.commands.dispatch workspaceElement, 'markdown-preview-plus:toggle'
+
+    expectPreviewInSplitPane()
+
+    waitsFor "mathjaxHelper.mathProcessor to be called", ->
+      mathjaxHelper.mathProcessor.calls.length
+
+    waitsForQueuedMathJax()
+
+  afterEach ->
+    preview.destroy()
+    $('script[src*="MathJax.js"]').remove()
+    window.MathJax = undefined # window is nessesary to prevent lexical scoping of MathJax to afterEach
+
+  expectPreviewInSplitPane = ->
+    runs ->
+      expect(atom.workspace.getPanes()).toHaveLength 2
+
+    waitsFor "markdown preview to be created", ->
+      preview = atom.workspace.getPanes()[1].getActiveItem()
+
+    runs ->
+      expect(preview).toBeInstanceOf(MarkdownPreviewView)
+      expect(preview.getPath()).toBe atom.workspace.getActivePaneItem().getPath()
+
+  waitsForQueuedMathJax = ->
+    [done] = []
+
+    callback = -> done = true
+    runs -> MathJax.Hub.Queue [callback]
+    waitsFor "queued MathJax operations to complete", -> done
+
+  generateSelector = (token) ->
+    selector = null
+    for element in token.path
+      if selector is null
+      then selector = ".update-preview > #{element.tag}:eq(#{element.index})"
+      else selector = "#{selector} > #{element.tag}:eq(#{element.index})"
+    return selector
+
+  describe "Syncronizing preview with source", ->
+    [sourceMap, tokens] = []
+
+    beforeEach ->
+      sourceMap = cson.readFileSync path.join(fixturesPath, 'sync-preview.cson')
+      tokens = markdownIt.getTokens preview.editor.getText(), true
+
+    it "identifies the correct HTMLElement path", ->
+      for sourceLine in sourceMap
+        elementPath = preview.getPathToToken tokens, sourceLine.line
+        for i in [0..(elementPath.length-1)] by 1
+          expect(elementPath[i].tag).toBe(sourceLine.path[i].tag)
+          expect(elementPath[i].index).toBe(sourceLine.path[i].index)
+
+    it "scrolls to the correct HTMLElement", ->
+      for sourceLine in sourceMap
+        selector = generateSelector(sourceLine)
+        if selector? then element = preview.find(selector)[0] else continue
+        syncElement = preview.syncPreview preview.editor.getText(), sourceLine.line
+        expect(element).toBe(syncElement)
+
+  describe "Syncronizing source with preview", ->
+    it "sets the editors cursor buffer location to the correct line", ->
+      sourceMap = cson.readFileSync path.join(fixturesPath, 'sync-source.cson')
+
+      for sourceElement in sourceMap
+        selector = generateSelector(sourceElement)
+        if selector? then element = preview.find(selector)[0] else continue
+        syncLine = preview.syncSource preview.editor.getText(), element
+        expect(syncLine).toBe(sourceElement.line) if syncLine

--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -165,8 +165,11 @@
   .flash {
     -webkit-animation: flash 1s ease-out;
     -webkit-animation-iteration-count: 1;
-    display: block;
     outline: 1px solid rgba(255,0,0,0);
+  }
+
+  .flash:not(li) {
+    display: block;
   }
 
   @-webkit-keyframes flash {

--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -162,4 +162,22 @@
     top: 50%;
   }
 
+  .flash {
+    -webkit-animation: flash 1s ease-out;
+    -webkit-animation-iteration-count: 1;
+    display: block;
+    outline: 1px solid rgba(255,0,0,0);
+  }
+
+  @-webkit-keyframes flash {
+      0% {
+        outline-color: rgba(255,0,0,0);
+      }
+      50% {
+        outline-color: rgba(255,0,0,1);
+      }
+      100% {
+        outline-color: rgba(255,0,0,0);
+      }
+  }
 }


### PR DESCRIPTION
This is to implement #9. Currently there are two context menu items 'Sync Preview' and 'Sync Source' for the source editor and preview respectively that sync the others scroll position. Further there is a keymap `alt-click` for the preview only that does the same as 'Sync Source':

![2 0 0-source-preview-sync 0 1 2](https://cloud.githubusercontent.com/assets/1201875/9423869/6e2d402a-48cf-11e5-8614-81231e832817.gif)

@leipert if you had a few free minutes today I would be great if you could give this a quick spin, send me any bugs you encounter which would really help with the specs I build today.

As a note on the keymaps, I personally would really like to have them, but I don't know about you? I have actually configured the preview to [prevent the `alt` key from bubbling](https://github.com/Galadirith/markdown-preview-plus/blob/98fa5013cd38959ba7ba3cf53b4d4c38107583b2/lib/markdown-preview-view.coffee#L122-L128) up to the window. For me this was important because the `alt` key toggles the menu bar on windows and its quite annoying. 

However I don't like disabling the alt key and it is probably not an issue for OS X or linux, and maybe not all Windows users. This is also the reason why I didn't enable the keymap on the editor, because disabling the `alt` key there would certainly be I think far to invasive and a UX anti-pattern.

If you can let me know yours thoughts, thanks @leipert :D