### PR TITLE
Correct instantiation conditions for markdown-it

### DIFF
--- a/lib/markdown-it-helper.coffee
+++ b/lib/markdown-it-helper.coffee
@@ -45,7 +45,9 @@ init = (rL) ->
     markdownIt.use math, mathBrackets
 
 needsInit = (rL) ->
-  markdownItOptions isnt getOptions() or markdownIt? or rL isnt renderLaTeX
+  not markdownIt? or
+  markdownItOptions.breaks isnt atom.config.get('markdown-preview-plus.breakOnSingleNewline') or
+  rL isnt renderLaTeX
 
 exports.render = (text, rL) ->
   init(rL) if needsInit(rL)


### PR DESCRIPTION
@leipert While I was twiddling away with #88 I noticed that `markdown-it` seems to still be being instanced for every edit of the source. It looks like a couple of the conditions weren't working:

1. Javascript doesn't seem to handle comparing objects so `markdownItOptions isnt getOptions()` was always returning true. I replaced this with `L49` as the only variable in the options is `markdown-preview-plus.breakOnSingleNewline`.
2. `markdownIt?` is false if `markdownIt === null || markdownIt === undefined` which is exactly the opposite of what we want.

I'm not sure if this really gives any perceived performance benefit, but not instancing every parse must be at least a little bit better :D