### PR TITLE
Fix math regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grim": "^1.2.1",
     "highlights": "^1.0.0",
     "markdown-it": "^4.4.0",
-    "markdown-it-math": "^2.0.1",
+    "markdown-it-math": "^3.0.1",
     "pathwatcher-without-runas": "~4.5.0",
     "pdc": "~0.2.2",
     "season": "^5.3",


### PR DESCRIPTION
With the migration to markdown-it we had several regressions in the math department. These are fixed now:

1. Single-Line Math Blocks like `$$E=mc^2$$` work again
2. Escape Delimiters correctly : `a $5, a $10 and a \$100 Bill. <- should not render any math`
3. Math Blocks after paragraphs:
```
In my opinion math blocks should work that way:
$$
x + y
$$
wuhu 
```

These work again. Wuhu!