### PR TITLE
Added support for lazy headers (missing space after #)

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,6 +1,3 @@
-#X
-# X
-
 $x$ math at the start of the document
 
 This document is to test $\LaTeX$ rendering with [markdown-preview-plus](https://atom.io/packages/markdown-preview-plus).

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,3 +1,6 @@
+#X
+# X
+
 $x$ math at the start of the document
 
 This document is to test $\LaTeX$ rendering with [markdown-preview-plus](https://atom.io/packages/markdown-preview-plus).

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -45,9 +45,14 @@ module.exports =
       type: 'boolean'
       default: false
       order: 40
+    useLazyHeaders:
+      title: 'Use Lazy Headers'
+      description: 'Require no space after headings #'
+      type: 'boolean'
+      default: true
+      order: 45
     useGitHubStyle:
       title: 'Use GitHub.com style'
-      description: 'Use github flavored markdown, for example: require no space after headings #'
       type: 'boolean'
       default: false
       order: 50

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -47,6 +47,7 @@ module.exports =
       order: 40
     useGitHubStyle:
       title: 'Use GitHub.com style'
+      description: 'Use github flavored markdown, for example: require no space after headings #'
       type: 'boolean'
       default: false
       order: 50

--- a/lib/markdown-it-helper.coffee
+++ b/lib/markdown-it-helper.coffee
@@ -45,7 +45,7 @@ init = (rL) ->
     markdownIt.use math, mathDollars
     markdownIt.use math, mathBrackets
 
-  lazyHeaders = atom.config.get('markdown-preview-plus.useGitHubStyle')
+  lazyHeaders = atom.config.get('markdown-preview-plus.useLazyHeaders')
 
   if lazyHeaders
     markdownIt.use require('markdown-it-lazy-headers')
@@ -54,7 +54,7 @@ init = (rL) ->
 needsInit = (rL) ->
   not markdownIt? or
   markdownItOptions.breaks isnt atom.config.get('markdown-preview-plus.breakOnSingleNewline') or
-  lazyHeaders isnt atom.config.get('markdown-preview-plus.useGitHubStyle') or
+  lazyHeaders isnt atom.config.get('markdown-preview-plus.useLazyHeaders') or
   rL isnt renderLaTeX
 
 exports.render = (text, rL) ->

--- a/lib/markdown-it-helper.coffee
+++ b/lib/markdown-it-helper.coffee
@@ -2,6 +2,7 @@ markdownIt = null
 markdownItOptions = null
 renderLaTeX = null
 math = null
+lazyHeaders = null
 
 mathInline = (string) -> "<span class='math'><script type='math/tex'>#{string}</script></span>"
 mathBlock = (string) -> "<span class='math'><script type='math/tex; mode=display'>#{string}</script></span>"
@@ -44,9 +45,16 @@ init = (rL) ->
     markdownIt.use math, mathDollars
     markdownIt.use math, mathBrackets
 
+  lazyHeaders = atom.config.get('markdown-preview-plus.useGitHubStyle')
+
+  if lazyHeaders
+    markdownIt.use require('markdown-it-lazy-headers')
+
+
 needsInit = (rL) ->
   not markdownIt? or
   markdownItOptions.breaks isnt atom.config.get('markdown-preview-plus.breakOnSingleNewline') or
+  lazyHeaders isnt atom.config.get('markdown-preview-plus.useGitHubStyle') or
   rL isnt renderLaTeX
 
 exports.render = (text, rL) ->

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grim": "^1.2.1",
     "highlights": "^1.0.0",
     "markdown-it": "^4.4.0",
+    "markdown-it-lazy-headers": "^0.1.2",
     "markdown-it-math": "^3.0.1",
     "pathwatcher-without-runas": "~4.5.0",
     "pdc": "~0.2.2",

--- a/spec/fixtures/subdir/file.markdown
+++ b/spec/fixtures/subdir/file.markdown
@@ -1,4 +1,8 @@
-## File.markdown
+# File.markdown
+
+##Level two header without space
+
+## Level two header with space
 
 :cool:
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -77,6 +77,31 @@ describe "MarkdownPreviewView", ->
         jasmine.attachToDOM(newPreview.element)
         expect(newPreview.getPath()).toBe preview.getPath()
 
+  describe "header rendering", ->
+
+    it "should render headings with and without space", ->
+
+      waitsForPromise -> preview.renderMarkdown()
+
+      runs ->
+        headlines = preview.find('h2')
+        expect(headlines).toExist()
+        expect(headlines.length).toBe(2)
+        expect(headlines[0].outerHTML).toBe("<h2>Level two header without space</h2>")
+        expect(headlines[1].outerHTML).toBe("<h2>Level two header with space</h2>")
+
+    it "should render headings with and without space", ->
+      atom.config.set 'markdown-preview-plus.useLazyHeaders', false
+
+      waitsForPromise -> preview.renderMarkdown()
+
+      runs ->
+        headlines = preview.find('h2')
+        expect(headlines).toExist()
+        expect(headlines.length).toBe(1)
+        expect(headlines[0].outerHTML).toBe("<h2>Level two header with space</h2>")
+
+
   describe "code block conversion to atom-text-editor tags", ->
     beforeEach ->
       waitsForPromise ->


### PR DESCRIPTION
This issue fixes #88 by using the `useGitHubStyle` option.

I didn't bother adding another option, as I think useGitHubStyle is sufficient. What do you think @Galadirith?