### PR TITLE
Fix cannot read property decode

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -4,11 +4,9 @@ cheerio = require 'cheerio'
 fs = require 'fs-plus'
 Highlights = require 'highlights'
 {$} = require 'atom-space-pen-views'
-roaster = null # Defer until used
 pandocHelper = null # Defer until used
 markdownIt = null # Defer until used
 {scopeForFenceName} = require './extension-helper'
-mathjaxHelper = require './mathjax-helper'
 pathWatcher = require 'pathwatcher-without-runas'
 
 MarkdownPreviewView = null # Defer until used

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -111,8 +111,10 @@ resolveImagePaths = (html, filePath) ->
   for imgElement in o('img')
     img = o(imgElement)
     if src = img.attr('src')
-      src = markdownIt.decode(src)
-      
+      if not atom.config.get('markdown-preview-plus.enablePandoc')
+        markdownIt ?= require './markdown-it-helper'
+        src = markdownIt.decode(src)
+
       continue if src.match(/^(https?|atom):\/\//)
       continue if src.startsWith(process.resourcesPath)
       continue if src.startsWith(resourcePath)

--- a/spec/fixtures/subdir/file-pandoc.html
+++ b/spec/fixtures/subdir/file-pandoc.html
@@ -1,0 +1,34 @@
+<h1 id="file.markdown">File.markdown</h1>
+<h2 id="level-two-header-without-space">Level two header without space</h2>
+<h2 id="level-two-header-with-space">Level two header with space</h2>
+<p>:cool:</p>
+<pre class="sourceCode ruby"><code class="sourceCode ruby"><span class="kw">def</span> func
+  x = <span class="dv">1</span>
+<span class="kw">end</span></code></pre>
+<ul>
+<li><p>This is a test</p>
+<pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">if</span> a === <span class="dv">3</span> {
+  b = <span class="dv">5</span>
+}</code></pre></li>
+</ul>
+<pre><code>function f(x) {
+  return x++;
+}</code></pre>
+<pre class="kombucha"><code>drink-that-stuff:
+  tastes-weird~</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> foo()
+
+  bar
+
+
+  baz</code></pre>
+<div class="figure">
+<img src="image1.png" alt="Image1"><p class="caption">Image1</p>
+</div>
+<div class="figure">
+<img src="/tmp/image2.png" alt="Image2"><p class="caption">Image2</p>
+</div>
+<div class="figure">
+<img src="https://raw.githubusercontent.com/Galadirith/markdown-preview-plus/master/assets/hr.png" alt="Image3"><p class="caption">Image3</p>
+</div>
+<p>lorem ipsum</p>

--- a/spec/markdown-preview-view-pandoc-spec.coffee
+++ b/spec/markdown-preview-view-pandoc-spec.coffee
@@ -1,0 +1,86 @@
+path = require 'path'
+fs = require 'fs-plus'
+temp = require 'temp'
+MarkdownPreviewView = require '../lib/markdown-preview-view'
+markdownIt = require '../lib/markdown-it-helper'
+pandocHelper = require '../lib/pandoc-helper.coffee'
+url = require 'url'
+queryString = require 'querystring'
+
+require './spec-helper'
+
+describe "MarkdownPreviewView when Pandoc is enabled", ->
+  [html, preview, filePath] = []
+
+  beforeEach ->
+    filePath = atom.project.getDirectories()[0].resolve('subdir/file.markdown')
+    htmlPath = atom.project.getDirectories()[0].resolve('subdir/file-pandoc.html')
+    html = fs.readFileSync htmlPath,
+      encoding: 'utf-8'
+
+    waitsForPromise ->
+      atom.packages.activatePackage('markdown-preview-plus')
+
+    runs ->
+      atom.config.set 'markdown-preview-plus.enablePandoc', true
+      spyOn(pandocHelper, 'renderPandoc').andCallFake (text, filePath, renderMath, cb) ->
+        cb null, html
+
+      preview = new MarkdownPreviewView({filePath})
+      jasmine.attachToDOM(preview.element)
+
+    this.addMatchers
+      toStartWith: (expected) ->
+        this.actual.slice(0, expected.length) is expected;
+
+  afterEach ->
+    preview.destroy()
+
+  describe "image resolving", ->
+    beforeEach ->
+      spyOn(markdownIt, 'decode').andCallThrough()
+      waitsForPromise ->
+        preview.renderMarkdown()
+
+    describe "when the image uses a relative path", ->
+      it "resolves to a path relative to the file", ->
+        image = preview.find("img[alt=Image1]")
+        expect(markdownIt.decode).not.toHaveBeenCalled()
+        expect(image.attr('src')).toStartWith atom.project.getDirectories()[0].resolve('subdir/image1.png')
+
+    describe "when the image uses an absolute path that does not exist", ->
+      it "resolves to a path relative to the project root", ->
+        image = preview.find("img[alt=Image2]")
+        expect(markdownIt.decode).not.toHaveBeenCalled()
+        expect(image.attr('src')).toStartWith atom.project.getDirectories()[0].resolve('tmp/image2.png')
+
+    describe "when the image uses an absolute path that exists", ->
+      it "adds a query to the URL", ->
+        preview.destroy()
+
+        filePath = path.join(temp.mkdirSync('atom'), 'foo.md')
+        fs.writeFileSync(filePath, "![absolute](#{filePath})")
+
+        jasmine.unspy(pandocHelper, 'renderPandoc')
+        spyOn(pandocHelper, 'renderPandoc').andCallFake (text, filePath, renderMath, cb) ->
+          cb null, """
+            <div class="figure">
+            <img src="#{filePath}" alt="absolute"><p class="caption">absolute</p>
+            </div>
+            """
+
+        preview = new MarkdownPreviewView({filePath})
+        jasmine.attachToDOM(preview.element)
+
+        waitsForPromise ->
+          preview.renderMarkdown()
+
+        runs ->
+          expect(markdownIt.decode).not.toHaveBeenCalled()
+          expect(preview.find("img[alt=absolute]").attr('src')).toStartWith "#{filePath}?v="
+
+    describe "when the image uses a web URL", ->
+      it "doesn't change the URL", ->
+        image = preview.find("img[alt=Image3]")
+        expect(markdownIt.decode).not.toHaveBeenCalled()
+        expect(image.attr('src')).toBe 'https://raw.githubusercontent.com/Galadirith/markdown-preview-plus/master/assets/hr.png'

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -2,13 +2,14 @@ path = require 'path'
 fs = require 'fs-plus'
 temp = require 'temp'
 MarkdownPreviewView = require '../lib/markdown-preview-view'
+markdownIt = require '../lib/markdown-it-helper'
 url = require 'url'
 queryString = require 'querystring'
 
 require './spec-helper'
 
 describe "MarkdownPreviewView", ->
-  [file, preview, workspaceElement] = []
+  [filePath, preview] = []
 
   beforeEach ->
     filePath = atom.project.getDirectories()[0].resolve('subdir/file.markdown')
@@ -143,17 +144,20 @@ describe "MarkdownPreviewView", ->
 
   describe "image resolving", ->
     beforeEach ->
+      spyOn(markdownIt, 'decode').andCallThrough()
       waitsForPromise ->
         preview.renderMarkdown()
 
     describe "when the image uses a relative path", ->
       it "resolves to a path relative to the file", ->
         image = preview.find("img[alt=Image1]")
+        expect(markdownIt.decode).toHaveBeenCalled()
         expect(image.attr('src')).toStartWith atom.project.getDirectories()[0].resolve('subdir/image1.png')
 
     describe "when the image uses an absolute path that does not exist", ->
       it "resolves to a path relative to the project root", ->
         image = preview.find("img[alt=Image2]")
+        expect(markdownIt.decode).toHaveBeenCalled()
         expect(image.attr('src')).toStartWith atom.project.getDirectories()[0].resolve('tmp/image2.png')
 
     describe "when the image uses an absolute path that exists", ->
@@ -169,15 +173,17 @@ describe "MarkdownPreviewView", ->
           preview.renderMarkdown()
 
         runs ->
+          expect(markdownIt.decode).toHaveBeenCalled()
           expect(preview.find("img[alt=absolute]").attr('src')).toStartWith "#{filePath}?v="
 
     describe "when the image uses a web URL", ->
       it "doesn't change the URL", ->
         image = preview.find("img[alt=Image3]")
+        expect(markdownIt.decode).toHaveBeenCalled()
         expect(image.attr('src')).toBe 'https://raw.githubusercontent.com/Galadirith/markdown-preview-plus/master/assets/hr.png'
 
   describe "image modification", ->
-    [dirPath, filePath, img1Path] = []
+    [dirPath, filePath, img1Path, workspaceElement] = []
 
     beforeEach ->
       preview.destroy()


### PR DESCRIPTION
A fix for #99 and its duplicates. I only initialize `markdownIt` and call `.decode()` if Pandoc is disabled as Pandoc src strings are not encoded.