### PR TITLE
Fix deserialization due to not passing domFragment

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -182,31 +182,7 @@ class MarkdownPreviewView extends ScrollView
         # be instanced in the constructor
         unless @updatePreview
           @updatePreview = new UpdatePreview(@find("div.update-preview")[0])
-        if @renderLaTeX and not MathJax?
-          @updatePreview.update(
-            '<p><strong>It looks like somethings missing. Lets fix
-            that :D</strong></p>
-            <p>Recent versions of
-            <a href="https://github.com/Galadirith/markdown-preview-plus">
-              markdown-preview-plus
-            </a>
-            require the package
-            <a href="https://github.com/Galadirith/mathjax-wrapper">
-              mathjax-wrapper
-            </a>
-            to be installed to preview LaTeX.
-            </p>
-            <p>
-            To install
-            <a href="https://github.com/Galadirith/mathjax-wrapper">
-              mathjax-wrapper
-            </a>
-            simply search for <strong>mathjax-wrapper</strong> in the menu
-            <strong>File &rsaquo; Settings &rsaquo; Packages</strong> and click
-            <strong>Install</strong>.'
-            , false)
-        else
-          @updatePreview.update(domFragment, @renderLaTeX)
+        @updatePreview.update(domFragment, @renderLaTeX)
         @emitter.emit 'did-change-markdown'
         @originalTrigger('markdown-preview-plus:markdown-changed')
 

--- a/lib/mathjax-helper.coffee
+++ b/lib/mathjax-helper.coffee
@@ -42,6 +42,15 @@ module.exports =
   mathProcessor: (domElements) ->
     if MathJax?
       MathJax.Hub.Queue ["Typeset", MathJax.Hub, domElements]
+    else
+      atom.notifications.addError """
+        It looks like your trying to render maths but
+        [`markdown-preview-plus`](https://atom.io/packages/markdown-preview-plus)
+        cannot find its maths rendering engine right now. Please make sure that
+        you have installed
+        [`mathjax-wrapper`](https://atom.io/packages/mathjax-wrapper) and try
+        re-opening your markdown preview.
+        """, dismissable: true
     return
 
 #
@@ -130,5 +139,6 @@ configureMathJax = ->
       Macros: userMacros
     messageStyle: "none"
     showMathMenu: false
+    skipStartupTypeset: true
   MathJax.Hub.Configured()
   return

--- a/lib/mathjax-helper.coffee
+++ b/lib/mathjax-helper.coffee
@@ -43,7 +43,7 @@ module.exports =
     if MathJax?
       MathJax.Hub.Queue ["Typeset", MathJax.Hub, domElements]
     else
-      atom.notifications.addError """
+      atom.notifications.addInfo """
         It looks like your trying to render maths but
         [`markdown-preview-plus`](https://atom.io/packages/markdown-preview-plus)
         cannot find its maths rendering engine right now. Please make sure that


### PR DESCRIPTION
Also fixes use cases when attempting to render maths without having installed `mathjax-wrapper`. Instead of an uncaught error, the preview will now render without maths and prompt to install `mathjax-wrapper`.

WIP towards fixing #104