### PR TITLE
Add MathJax as explicit dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ notifications:
     on_success: never
     on_failure: change
 
-env:
-  - APM_TEST_PACKAGES="mathjax-wrapper"
-
 script:
   - '(curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh) || true'
   - './node_modules/.bin/coffeelint lib'

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ We also have a more detailed description of [features][features].
 
 Long instructions can be found [here][installation]. In short steps:
 
-1.  Install this package and [`mathjax-wrapper`][mathjax-wrapper]. Installation
-    of `mathjax-wrapper` may take a long time.
-2.  Disable built-in package *Markdown Preview*.
-3.  (Optional) Enable pandoc.
+1.  Search for and install `markdown-preview-plus` in Atom's Settings view.
+2.  Search for and disable the built-in package `markdown-preview`.
+3.  (Optional) Install and enable [Pandoc][pandoc].
 
 ## Usage
 
@@ -55,8 +54,8 @@ Markdown Preview Plus (MPP) is released under the [MIT license][license].
 [math]: docs/math.md
 [features]: docs/features.md
 [node-gyp]: https://github.com/TooTallNate/node-gyp#installation
-[mathjax-wrapper]: https://atom.io/packages/mathjax-wrapper
 [options]: docs/options.md
+[pandoc]: http://pandoc.org
 
 [ad]: https://img.shields.io/apm/dm/markdown-preview-plus.svg
 [av]: https://img.shields.io/apm/v/markdown-preview-plus.svg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,6 @@ version: "{build}"
 build: off
 deploy: off
 
-cache:
-  - C:\Users\appveyor\.atom\packages\mathjax-wrapper
-  - C:\Users\appveyor\mathjax.version
-
 install:
   - cd %LOCALAPPDATA%
   - ps: (New-Object Net.WebClient).DownloadFile("https://github.com/atom/atom/releases/download/$((Invoke-RestMethod -Method Get -Uri 'http://latest-atom-version.xyz/').trim())/atom-windows.zip", "$(pwd)\atom-windows.zip")
@@ -14,25 +10,6 @@ install:
   - SET PATH=%LOCALAPPDATA%\Atom\resources\app\apm\bin;%LOCALAPPDATA%\Atom\;%PATH%
   - apm --version
   - atom --version
-  - ps: |
-      If (Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json){
-        (New-Object Net.WebClient).DownloadFile("https://github.com/stedolan/jq/releases/download/jq-1.4/jq-win32.exe", "$(pwd)\jq-win32.exe")
-        $a = (apm view mathjax-wrapper --json | .\jq-win32.exe '.version') | Out-String
-        $b = (.\jq-win32.exe '.version' $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json) | Out-String
-        Write-Host $a$b
-        If ($a.CompareTo($b)){
-          Write-Host "Newer mathjax version available, we delete the old one"
-          Remove-Item $env:USERPROFILE\.atom\packages\mathjax-wrapper -recurse -Force
-        }Else{
-          Write-Host "Mathjax Versions match"
-        }
-      }
-  - ps: |
-      If (Test-Path $env:USERPROFILE\.atom\packages\mathjax-wrapper\package.json){
-        Write-Host "Atom mathjax-wrapper already installed"
-      }Else{
-        apm install mathjax-wrapper
-      }
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,8 +2,8 @@
 
 1.  **Install MPP**
 
-    Search for **Markdown Preview Plus** in the menu **File &rsaquo; Settings
-    &rsaquo; Install** and click **Install**. Please allow 3-5 mins for
+    Search for **Markdown Preview Plus** in Atom's Settings view **File &rsaquo;
+    Settings &rsaquo; Install** and click **Install**. Please allow 3-5 mins for
     installation. Alternatively if you would prefer to use the command line
     utility `apm`:
 
@@ -11,24 +11,13 @@
     apm install markdown-preview-plus
     ````
 
-2.  **Install mathjax-wrapper**
-
-    Search for **mathjax-wrapper** in the menu **File &rsaquo; Settings &rsaquo;
-    Install** and click **Install**. Please allow 10-15 mins for installation
-    of mathjax-wrapper. Alternatively if you would prefer to use the command
-    line utility `apm`:
-
-    ````bash
-    apm install mathjax-wrapper
-    ````
-
-3.  **Disable Markdown Preview**
+2.  **Disable Markdown Preview**
 
     Disable the built in Markdown Preview package. You can do this by searching
-    for **Markdown Preview** in the menu **File &rsaquo; Settings &rsaquo;
-    Packages** and clicking **Disable**.
+    for **Markdown Preview** in Atom's Settings view **File &rsaquo; Settings
+    &rsaquo; Packages** and clicking **Disable**.
 
-4.  **(Optional) Enable Pandoc**
+3.  **(Optional) Enable Pandoc**
 
     Optionally you may use Pandoc to render the Markdown preview. To enable
     Pandoc within MPP:

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -145,9 +145,6 @@ module.exports =
     atom.commands.add '.tree-view .file .name[data-name$=\\.ron]', 'markdown-preview-plus:preview-file', previewFile
     atom.commands.add '.tree-view .file .name[data-name$=\\.txt]', 'markdown-preview-plus:preview-file', previewFile
 
-    # Call to load MathJax environment
-    require('./mathjax-helper').loadMathJax()
-
     atom.workspace.addOpener (uriToOpen) ->
       try
         {protocol, host, pathname} = url.parse(uriToOpen)

--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -16,10 +16,7 @@ config = {}
  ###
 getMathJaxPath = ->
   try
-    path ?= require 'path'
-    config.mathjax = atom.packages.getLoadedPackage('mathjax-wrapper')
-    config.mathjax = path.join config.mathjax.path, 'node_modules/MathJax/MathJax.js'
-    config.mathjax = config.mathjax
+    config.mathjax = require.resolve 'MathJax'
   catch e
     config.mathjax = ''
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grim": "^1.2.1",
     "highlights-native": "^2.1.0",
     "lodash": "^3.10.1",
+    "MathJax": "https://github.com/Galadirith/MathJax/tarball/2.4.0-electron.0.2.0",
     "markdown-it": "^4.4.0",
     "markdown-it-lazy-headers": "^0.1.2",
     "markdown-it-math": "^3.0.1",

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -3,6 +3,7 @@ fs = require 'fs-plus'
 temp = require 'temp'
 MarkdownPreviewView = require '../lib/markdown-preview-view'
 markdownIt = require '../lib/markdown-it-helper'
+mathjaxHelper = require '../lib/mathjax-helper'
 url = require 'url'
 queryString = require 'querystring'
 
@@ -543,7 +544,7 @@ describe "MarkdownPreviewView", ->
         """
 
   describe "when maths rendering is enabled by default", ->
-    it "renders the preview without maths if it cannot find MathJax", ->
+    it "notifies the user MathJax is loading when first preview is opened", ->
       [workspaceElement] = []
 
       preview.destroy()
@@ -557,6 +558,7 @@ describe "MarkdownPreviewView", ->
       waitsForPromise -> atom.workspace.open(filePath)
 
       runs ->
+        mathjaxHelper.resetMathJax()
         atom.config.set 'markdown-preview-plus.enableLatexRenderingByDefault', true
         atom.commands.dispatch workspaceElement, 'markdown-preview-plus:toggle'
 

--- a/spec/mathjax-helper-spec.coffee
+++ b/spec/mathjax-helper-spec.coffee
@@ -15,18 +15,19 @@ describe "MathJax helper module", ->
       spyOn(atom, 'getConfigDirPath').andReturn configDirPath
       jasmine.useRealClock() # MathJax queue's will NOT work without this
 
-      waitsForPromise ->
-        atom.packages.activatePackage("mathjax-wrapper")
+      mathjaxHelper.resetMathJax()
 
     afterEach ->
-      $('script[src*="MathJax.js"]').remove()
-      window.MathJax = undefined # window is nessesary to prevent lexical scoping of MathJax to afterEach
+      mathjaxHelper.resetMathJax()
 
     waitsForMacrosToLoad = ->
       [span] = []
 
       waitsForPromise ->
         atom.packages.activatePackage("markdown-preview-plus")
+
+      runs ->
+        mathjaxHelper.loadMathJax()
 
       waitsFor "MathJax to load", ->
         MathJax?

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -21,14 +21,10 @@ describe "Syncronization of source and preview", ->
     configDirPath = temp.mkdirSync('atom-config-dir-')
     spyOn(atom, 'getConfigDirPath').andReturn configDirPath
 
-    waitsForPromise ->
-      atom.packages.activatePackage("mathjax-wrapper")
+    mathjaxHelper.resetMathJax()
 
     waitsForPromise ->
       atom.packages.activatePackage("markdown-preview-plus")
-
-    waitsFor "MathJax to load", ->
-      MathJax?
 
     waitsFor "LaTeX rendering to be enabled", ->
       atom.config.set 'markdown-preview-plus.enableLatexRenderingByDefault', true
@@ -45,12 +41,14 @@ describe "Syncronization of source and preview", ->
     waitsFor "mathjaxHelper.mathProcessor to be called", ->
       mathjaxHelper.mathProcessor.calls.length
 
+    waitsFor "MathJax to load", ->
+      MathJax?
+
     waitsForQueuedMathJax()
 
   afterEach ->
     preview.destroy()
-    $('script[src*="MathJax.js"]').remove()
-    window.MathJax = undefined # window is nessesary to prevent lexical scoping of MathJax to afterEach
+    mathjaxHelper.resetMathJax()
 
   expectPreviewInSplitPane = ->
     runs ->

--- a/wercker.yml
+++ b/wercker.yml
@@ -6,8 +6,7 @@ build:
     - script:
         name: Install dependencies
         code: >
-          apm install &&
-          apm install mathjax-wrapper
+          apm install
     - script:
         name: Test package
         code: >


### PR DESCRIPTION
This PR is to remove need to install [`mathjax-wrapper`](https://atom.io/packages/mathjax-wrapper) as an external dependency. Now MathJax is included through an explicit node dependency [2.4.0-electron.0.2.0](https://github.com/Galadirith/MathJax/releases/tag/2.4.0-electron.0.2.0). More specifically this does away with the ~50MB installation of `mathjax-wrapper` and the enormous i/o required to extract ~30000 and is replaced with a small ~3MB installation with ~300 files :D

The process of loading MathJax has also been improved. Now MathJax is loaded on demand only when maths rendering has been enabled and specs updated to reflect these changes.

@leipert would you mind checking the CI config changes I made.