### PR TITLE
Fixes #128

### DIFF
--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -62,7 +62,7 @@ setPandocOptions = (filePath) ->
  * @return {array} with Arguments for callbackFunction (error set to null)
  ###
 handleError = (error, html) ->
-  referenceSearch = /pandoc-citeproc: reference ([\S]+) not found?/ig
+  referenceSearch = /pandoc-citeproc: reference ([\S]+) not found/ig
   message =
     _.uniq error.message.split '\n'
     .join('<br>')

--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -62,7 +62,7 @@ setPandocOptions = (filePath) ->
  * @return {array} with Arguments for callbackFunction (error set to null)
  ###
 handleError = (error, html) ->
-  referenceSearch = /pandoc-citeproc: reference ([\S]+) not found(<br>)?/ig
+  referenceSearch = /pandoc-citeproc: reference ([\S]+) not found?/ig
   message =
     _.uniq error.message.split '\n'
     .join('<br>')


### PR DESCRIPTION
Fixes #128 - small bug preventing MPP from correctly reporting the error message on pandoc missing citation. MPP now identifies the citation missing from the .bib library as intended.
