### PR TITLE
Use syntax background color for table backgrounds.

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -67,6 +67,11 @@
   h6 + p {
     margin-top: 0;
   }
+  
+  // Allow tables to keep the background color of the editor theme
+  table, table * {
+    background: @syntax-background-color;
+  }
 
   // ReST first graf in nested list
   li p.first {


### PR DESCRIPTION
Not sure if this is the right place to address this issue, but it works like a charm for me. -- this might be better done in an upstream package? 

Addresses #161.