### PR TITLE
Use new promise api

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -200,7 +200,7 @@ module.exports =
       searchAllPanes: true
     if atom.config.get('markdown-preview-plus.openPreviewInSplitPane')
       options.split = 'right'
-    atom.workspace.open(uri, options).done (markdownPreviewView) ->
+    atom.workspace.open(uri, options).then (markdownPreviewView) ->
       if isMarkdownPreviewView(markdownPreviewView)
         previousActivePane.activate()
 


### PR DESCRIPTION
Atom now uses ES6 Promises instead of Q. Call promise.then instead of promise.done

Should resolve issue #149