### PR TITLE
Verify file path is string before reading and rendering

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,5 @@
 url = require 'url'
+fs = require 'fs-plus'
 
 MarkdownPreviewView = null # Defer until used
 renderer = null # Defer until used

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -121,6 +121,11 @@ module.exports =
 
 
   activate: ->
+    if parseFloat(atom.getVersion()) < 1.7
+      atom.deserializers.add
+        name: 'MarkdownPreviewView'
+        deserialize: module.exports.createMarkdownPreviewView.bind(module.exports)
+
     atom.commands.add 'atom-workspace',
       'markdown-preview-plus:toggle': =>
         @toggle()
@@ -230,9 +235,3 @@ module.exports =
           callback(proHTML)
       else
         callback(html)
-
-if parseFloat(atom.getVersion()) < 1.7
-  atom.deserializers.add(
-    name: 'MarkdownPreviewView'
-    deserialize: module.exports.createMarkdownPreviewView.bind(module.exports)
-  )

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -127,9 +127,8 @@ module.exports =
     atom.deserializers.add
       name: 'MarkdownPreviewView'
       deserialize: (state) ->
-        if state.constructor is Object
-          if state.editorId or fs.isFileSync(state.filePath)
-            createMarkdownPreviewView(state)
+        if state.editorId or fs.isFileSync(state.filePath)
+          createMarkdownPreviewView(state)
 
     atom.commands.add 'atom-workspace',
       'markdown-preview-plus:toggle': =>

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -127,7 +127,9 @@ module.exports =
     atom.deserializers.add
       name: 'MarkdownPreviewView'
       deserialize: (state) ->
-        createMarkdownPreviewView(state) if state.constructor is Object
+        if state.constructor is Object
+          if state.editorId or fs.isFileSync(state.filePath)
+            createMarkdownPreviewView(state)
 
     atom.commands.add 'atom-workspace',
       'markdown-preview-plus:toggle': =>

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -161,7 +161,7 @@ class MarkdownPreviewView extends ScrollView
     @getMarkdownSource().then (source) => @renderMarkdownText(source) if source?
 
   getMarkdownSource: ->
-    if @file?
+    if @file? and typeof @file.path is 'string'
       @file.read()
     else if @editor?
       Promise.resolve(@editor.getText())

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -42,7 +42,7 @@ class MarkdownPreviewView extends ScrollView
 
   serialize: ->
     deserializer: 'MarkdownPreviewView'
-    filePath: @getPath()
+    filePath: @getPath() ? @filePath
     editorId: @editorId
 
   destroy: ->

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -161,7 +161,7 @@ class MarkdownPreviewView extends ScrollView
     @getMarkdownSource().then (source) => @renderMarkdownText(source) if source?
 
   getMarkdownSource: ->
-    if @file? and typeof @file.path is 'string'
+    if @file?.getPath()
       @file.read()
     else if @editor?
       Promise.resolve(@editor.getText())

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   "devDependencies": {
     "coffeelint": "^1.9.7",
     "jasmine-tagged": "^1.1.4"
+  },
+  "deserializers": {
+    "MarkdownPreviewView": "createMarkdownPreviewView"
   }
 }

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -67,12 +67,23 @@ describe "MarkdownPreviewView", ->
     newPreview = null
 
     afterEach ->
-      newPreview.destroy()
+      newPreview?.destroy()
 
-    it "recreates the file when serialized/deserialized", ->
+    it "recreates the preview when serialized/deserialized", ->
       newPreview = atom.deserializers.deserialize(preview.serialize())
       jasmine.attachToDOM(newPreview.element)
       expect(newPreview.getPath()).toBe preview.getPath()
+
+    it "does not recreate a preview when the file no longer exists", ->
+      filePath = path.join(temp.mkdirSync('markdown-preview-'), 'foo.md')
+      fs.writeFileSync(filePath, '# Hi')
+
+      preview = new MarkdownPreviewView({filePath})
+      serialized = preview.serialize()
+      fs.removeSync(filePath)
+
+      newPreview = atom.deserializers.deserialize(serialized)
+      expect(newPreview).toBeUndefined()
 
     it "serializes the editor id when opened for an editor", ->
       preview.destroy()

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -78,8 +78,8 @@ describe "MarkdownPreviewView", ->
       filePath = path.join(temp.mkdirSync('markdown-preview-'), 'foo.md')
       fs.writeFileSync(filePath, '# Hi')
 
-      preview = new MarkdownPreviewView({filePath})
-      serialized = preview.serialize()
+      newPreview = new MarkdownPreviewView({filePath})
+      serialized = newPreview.serialize()
       fs.removeSync(filePath)
 
       newPreview = atom.deserializers.deserialize(serialized)


### PR DESCRIPTION
WIP cherry-picked from atom/markdown-preview#273 (existential checks) and atom/markdown-preview#367 (deserialization).