### PR TITLE
refact: change mathjax cdn url from http to https

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -313,7 +313,7 @@ class MarkdownPreviewView extends ScrollView
                   showMathMenu: false
                 });
               </script>
-              <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js">
+              <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
               </script>
               """
           else


### PR DESCRIPTION
This could help websites those who block http url such as `github page` to show right Math Formulas.
